### PR TITLE
Fix parameter error in guide

### DIFF
--- a/website/docs/basics/guides/devchain.md
+++ b/website/docs/basics/guides/devchain.md
@@ -388,7 +388,7 @@ wallet transfer --from-account "miner's address" --to-address "new account's add
 <summary>(click here to view result)</summary>
 
 ```bash
-CKB> wallet transfer --from-account ckt1qyqg6cnaankwgwvh0gaq49uptd3aawhl9p6qpg5cus --to-address ckt1qyq0g9p6nxf5cdy38fm35zech5f90jl5aueqnsxch5 --capacity 10000 --tx-fee 0.00001
+CKB> wallet transfer --from-account ckt1qyqg6cnaankwgwvh0gaq49uptd3aawhl9p6qpg5cus --to-address ckt1qyq0g9p6nxf5cdy38fm35zech5f90jl5aueqnsxch5 --capacity 10000 --max-tx-fee 0.00001
 Password: 
 0x1b66aafaaba5ce34de494f60374ef78e8f536bb3af9cab4fa63c0f29374c3f89
 ```


### PR DESCRIPTION

```console
error: Found argument '--tx-fee' which wasn't expected, or isn't valid in this context

	Did you mean '--max-tx-fee'?

If you tried to supply `--tx-fee` as a PATTERN use `-- --tx-fee`

USAGE:
    wallet transfer --to-address <to-address> --capacity <capacity> --from-account <from-account> --max-tx-fee <capacity>

```