### PR TITLE
chore: redirect old-doc to v1 vercel

### DIFF
--- a/website/static/js/extra.js
+++ b/website/static/js/extra.js
@@ -2,7 +2,7 @@ window.addEventListener("DOMContentLoaded", function () {
   const oldSiteLink = document.createElement("div");
   oldSiteLink.innerHTML = `<div id="oldSiteLink">
                     <div>
-                        <span>Note we've completely rebuilt Nervos Doc site! </span><span>For the old doc site, please see <a href="https://docs-old.nervos.org">docs-old</a>.</span>
+                        <span>Note we've completely rebuilt Nervos Doc site! </span><span>For the old doc site, please see <a href="https://nervos-ckb-docs-git-v1-cryptape.vercel.app/">docs-old</a>.</span>
                     </div>
                 </div>`;
   document.querySelector("body").prepend(oldSiteLink);


### PR DESCRIPTION
the old-doc site will be redirected to the Vercel branch. 

the source code of the old-doc site is located in branch `v1`
- https://github.com/nervosnetwork/docs.nervos.org/tree/v1