### PR TITLE
fix: Github token permission for GH deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,6 +5,12 @@ on:
     branches: [develop]
     paths: [website/**]
 
+permissions: # Define the permissions for the GITHUB_TOKEN
+  contents: write
+  actions: write
+  deployments: write
+  pages: write
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
**Issue**
Github pages deployments failing because GITHUB_TOKEN does not have adequate permissions.

**Fix:**
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defining-access-for-the-github_token-scopes