### PR TITLE
Send search terms to GA

### DIFF
--- a/website/static/js/extra.js
+++ b/website/static/js/extra.js
@@ -6,9 +6,21 @@ window.addEventListener("DOMContentLoaded", function () {
                     </div>
                 </div>`;
   document.querySelector("body").prepend(oldSiteLink);
-});
 
-/** Redirect users to /docs/getting-started */
-if (window.location.pathname === '/docs') {
-  window.location.pathname = '/docs/getting-started';
-}
+  // Redirect users to /docs/getting-started
+  if (window.location.pathname === '/docs') {
+    window.location.pathname = '/docs/getting-started';
+  }
+
+  // Keeps track of search term in GA
+  document.addEventListener('keydown', function(event) {
+    const target = event.target;
+    const isSearchInput = target.classList.contains('aa-Input') && target.type === 'search';
+    if (isSearchInput && event.key === 'Enter') {
+      window.gtag && window.gtag('event', 'search', {
+        event_category: 'Site Search',
+        event_label: target.value
+      });
+    }
+  });
+});


### PR DESCRIPTION
Description:
- I'm leveraging the aa-Input class to identify search input fields and trigger a GA event ('search') when users press the ENTER key, ensuring search terms are captured and sent as "event_label"

To test:
- Go to "Realtime" and look for "search" under the Event widget
![Screenshot 2024-04-24 at 4 30 24 PM](https://github.com/nervosnetwork/docs.nervos.org/assets/140578792/3387b20a-fd35-4988-a667-48bcc1bae00e)
