### PR TITLE
fix: broken link & tools for scripts

### DIFF
--- a/website/docs/getting-started/quick-start.mdx
+++ b/website/docs/getting-started/quick-start.mdx
@@ -5,6 +5,7 @@ title: Quick Start (5min)
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import ScriptTools from "../script/_ScriptTools.mdx";
 
 # Quick Start (5min)
 
@@ -168,22 +169,7 @@ The boilerplate project for a full-stack CKB dApp comprises two main components:
 
 By default, the Next.js template comes with a simple Script `hello-world` under `contracts/hello-world/src/main.rs`.
 
-:::info Tools You Need
-
-- [git](https://git-scm.com/), [make](https://www.tutorialspoint.com/unix_commands/make.htm), [sed](https://www.gnu.org/software/sed/), [bash](https://www.gnu.org/software/bash/), [sha256sum](https://linux.die.net/man/1/sha256sum) and others Unix utilities.
-- [Rust](https://www.rust-lang.org/) with `riscv64 target`: `rustup target add riscv64imac-unknown-none-elf`
-- [Clang 16+](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html)
-
-  - Debian / Ubuntu: ` wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo./llvm.sh 16 && rm llvm.sh`
-  - Fedora 39+: `sudo dnf -y install clang`
-  - Archlinux: `sudo pacman --noconfirm -Syu clang`
-  - MacOS (with [Homebrew](https://brew.sh/)): `brew install llvm@16`
-  - Windows (with [Scoop](https://scoop.sh/)): `scoop install llvm yasm`
-
-- [Cargo-generate](https://github.com/cargo-generate/cargo-generate)
-
-Check out the `ckb-script-templates` for more [details](https://github.com/cryptape/ckb-script-templates/blob/main/README.md#dependencies).
-:::
+<ScriptTools />
 
 ### Script-Related Commands
 

--- a/website/docs/getting-started/quick-start.mdx
+++ b/website/docs/getting-started/quick-start.mdx
@@ -18,7 +18,7 @@ OffCKB provides a one-line command to start a local blockchain (CKB Devnet) with
 npm install -g @offckb/cli
 ```
 
-:::note
+:::info
 Throughout this documentation, we use offckb/cli version **>=0.2.2**. You can always run the above command to update to the latest version.
 :::
 
@@ -164,15 +164,22 @@ Once the server is up and running, you can view the dApp by visiting [localhost:
 The boilerplate project for a full-stack CKB dApp comprises two main components:
 
 - The frontend, which utilizes the CKB JavaScript framework, [Lumos](https://github.com/ckb-js/lumos).
-- The Scripts, which leverages the [ckb-script-templates](https://github.com/nervosnetwork/ckb-script-templates).
+- The Scripts, which leverage the [ckb-script-templates](https://github.com/cryptape/ckb-script-templates).
 
 By default, the Next.js template comes with a simple Script `hello-world` under `contracts/hello-world/src/main.rs`.
 
-:::note Tools You Need
+:::info Tools You Need
 
 - [git](https://git-scm.com/), [make](https://www.tutorialspoint.com/unix_commands/make.htm), [sed](https://www.gnu.org/software/sed/), [bash](https://www.gnu.org/software/bash/), [sha256sum](https://linux.die.net/man/1/sha256sum) and others Unix utilities.
 - [Rust](https://www.rust-lang.org/) with `riscv64 target`: `rustup target add riscv64imac-unknown-none-elf`
 - [Clang 16+](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html)
+
+  - Debian / Ubuntu: ` wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo./llvm.sh 16 && rm llvm.sh`
+  - Fedora 39+: `sudo dnf -y install clang`
+  - Archlinux: `sudo pacman --noconfirm -Syu clang`
+  - MacOS (with [Homebrew](https://brew.sh/)): `brew install llvm@16`
+  - Windows (with [Scoop](https://scoop.sh/)): `scoop install llvm yasm`
+
 - [Cargo-generate](https://github.com/cargo-generate/cargo-generate)
 
 Check out the `ckb-script-templates` for more [details](https://github.com/cryptape/ckb-script-templates/blob/main/README.md#dependencies).

--- a/website/docs/script/ScriptHeaders.tsx
+++ b/website/docs/script/ScriptHeaders.tsx
@@ -38,6 +38,14 @@ export const ScriptHeaders: ScriptHeadersType = {
         </a>
         ,
         <a
+          href="https://www.gnu.org/software/sed/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          sed
+        </a>
+        ,
+        <a
           href="https://www.gnu.org/software/bash/"
           target="_blank"
           rel="noopener noreferrer"
@@ -67,7 +75,7 @@ export const ScriptHeaders: ScriptHeadersType = {
         >
           Clang 16+
         </a>
-        {" sample installtion steps for selected platforms are:"}
+
         <ul>
           <li>
             Debian / Ubuntu:{" "}
@@ -83,10 +91,11 @@ export const ScriptHeaders: ScriptHeadersType = {
             Archlinux: <code>sudo pacman --noconfirm -Syu clang</code>
           </li>
           <li>
-            macOS: <code>brew install llvm@16</code>
+            MacOS (with <a href="https://brew.sh/">Homebrew</a>):{" "}
+            <code>brew install llvm@16</code>
           </li>
           <li>
-            Windows(with [Scoop](scoop install llvm yasm)):{" "}
+            Windows (with <a href="https://scoop.sh/">Scoop</a>):{" "}
             <code>scoop install llvm yasm</code>
           </li>
         </ul>

--- a/website/docs/script/_ScriptTools.mdx
+++ b/website/docs/script/_ScriptTools.mdx
@@ -1,0 +1,16 @@
+:::info Tools You Need
+
+- [git](https://git-scm.com/), [make](https://www.tutorialspoint.com/unix_commands/make.htm), [sed](https://www.gnu.org/software/sed/), [bash](https://www.gnu.org/software/bash/), [sha256sum](https://linux.die.net/man/1/sha256sum) and others Unix utilities.
+- [Rust](https://www.rust-lang.org/) with `riscv64 target`: `rustup target add riscv64imac-unknown-none-elf`
+- [Clang 16+](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html)
+
+  - Debian / Ubuntu: ` wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo./llvm.sh 16 && rm llvm.sh`
+  - Fedora 39+: `sudo dnf -y install clang`
+  - Archlinux: `sudo pacman --noconfirm -Syu clang`
+  - MacOS (with [Homebrew](https://brew.sh/)): `brew install llvm@16`
+  - Windows (with [Scoop](https://scoop.sh/)): `scoop install llvm yasm`
+
+- [Cargo-generate](https://github.com/cargo-generate/cargo-generate)
+
+Check out the `ckb-script-templates` for more [details](https://github.com/cryptape/ckb-script-templates/blob/main/README.md#dependencies).
+:::

--- a/website/docs/script/a-minimal-script.mdx
+++ b/website/docs/script/a-minimal-script.mdx
@@ -44,12 +44,20 @@ Below is a step-by-step guide, and you can also clone the full code example from
 
 The first step is to create a new Script project. We use [ckb-script-templates](https://github.com/cryptape/ckb-script-templates) for this purpose. You will need the following dependencies:
 
-- `git`, `make`, `sed`, `bash`, `sha256sum` and others Unix utilities
-- `Rust` with `riscv64` target installed: `rustup target add riscv64imac-unknown-none-elf`
-- `Clang 16+`
-- `cargo-generate`: You can install this via `cargo install cargo-generate`
+:::info Tools You Need
 
-If you got any problems for these dependencies, refer to [readme](https://github.com/cryptape/ckb-script-templates?tab=readme-ov-file#dependencies) for install details.
+- [git](https://git-scm.com/), [make](https://www.tutorialspoint.com/unix_commands/make.htm), [sed](https://www.gnu.org/software/sed/), [bash](https://www.gnu.org/software/bash/), [sha256sum](https://linux.die.net/man/1/sha256sum) and others Unix utilities.
+- [Rust](https://www.rust-lang.org/) with `riscv64 target`: `rustup target add riscv64imac-unknown-none-elf`
+- [Clang 16+](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html)
+- [Cargo-generate](https://github.com/cargo-generate/cargo-generate)
+  - Debian / Ubuntu: ` wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo./llvm.sh 16 && rm llvm.sh`
+  - Fedora 39+: `sudo dnf -y install clang`
+  - Archlinux: `sudo pacman --noconfirm -Syu clang`
+  - MacOS (with [Homebrew](https://brew.sh/)): `brew install llvm@16`
+  - Windows (with [Scoop](https://scoop.sh/)): `scoop install llvm yasm`
+
+Check out the `ckb-script-templates` for more [details](https://github.com/cryptape/ckb-script-templates/blob/main/README.md#dependencies).
+:::
 
 ### Init a Script Project
 

--- a/website/docs/script/a-minimal-script.mdx
+++ b/website/docs/script/a-minimal-script.mdx
@@ -7,6 +7,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import ScriptHeaders from "./ScriptHeaders.tsx";
 import TutorialHeader from "@components/TutorialHeader";
+import ScriptTools from "./_ScriptTools.mdx";
 
 # Tutorial: A Minimal Script
 
@@ -44,20 +45,7 @@ Below is a step-by-step guide, and you can also clone the full code example from
 
 The first step is to create a new Script project. We use [ckb-script-templates](https://github.com/cryptape/ckb-script-templates) for this purpose. You will need the following dependencies:
 
-:::info Tools You Need
-
-- [git](https://git-scm.com/), [make](https://www.tutorialspoint.com/unix_commands/make.htm), [sed](https://www.gnu.org/software/sed/), [bash](https://www.gnu.org/software/bash/), [sha256sum](https://linux.die.net/man/1/sha256sum) and others Unix utilities.
-- [Rust](https://www.rust-lang.org/) with `riscv64 target`: `rustup target add riscv64imac-unknown-none-elf`
-- [Clang 16+](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html)
-- [Cargo-generate](https://github.com/cargo-generate/cargo-generate)
-  - Debian / Ubuntu: ` wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo./llvm.sh 16 && rm llvm.sh`
-  - Fedora 39+: `sudo dnf -y install clang`
-  - Archlinux: `sudo pacman --noconfirm -Syu clang`
-  - MacOS (with [Homebrew](https://brew.sh/)): `brew install llvm@16`
-  - Windows (with [Scoop](https://scoop.sh/)): `scoop install llvm yasm`
-
-Check out the `ckb-script-templates` for more [details](https://github.com/cryptape/ckb-script-templates/blob/main/README.md#dependencies).
-:::
+<ScriptTools />
 
 ### Init a Script Project
 

--- a/website/docs/script/js-script.mdx
+++ b/website/docs/script/js-script.mdx
@@ -7,6 +7,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import ScriptHeaders from "./ScriptHeaders.tsx";
 import TutorialHeader from "@components/TutorialHeader";
+import ScriptTools from "./_ScriptTools.mdx";
 
 # Tutorial: Run JavaScript Code on CKB
 
@@ -110,20 +111,7 @@ understanding.
 
 The first step is to create a new Script project. We use [ckb-script-templates](https://github.com/cryptape/ckb-script-templates) for this purpose. You will need the following dependencies:
 
-:::info Tools You Need
-
-- [git](https://git-scm.com/), [make](https://www.tutorialspoint.com/unix_commands/make.htm), [sed](https://www.gnu.org/software/sed/), [bash](https://www.gnu.org/software/bash/), [sha256sum](https://linux.die.net/man/1/sha256sum) and others Unix utilities.
-- [Rust](https://www.rust-lang.org/) with `riscv64 target`: `rustup target add riscv64imac-unknown-none-elf`
-- [Clang 16+](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html)
-- [Cargo-generate](https://github.com/cargo-generate/cargo-generate)
-  - Debian / Ubuntu: ` wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo./llvm.sh 16 && rm llvm.sh`
-  - Fedora 39+: `sudo dnf -y install clang`
-  - Archlinux: `sudo pacman --noconfirm -Syu clang`
-  - MacOS (with [Homebrew](https://brew.sh/)): `brew install llvm@16`
-  - Windows (with [Scoop](https://scoop.sh/)): `scoop install llvm yasm`
-
-Check out the `ckb-script-templates` for more [details](https://github.com/cryptape/ckb-script-templates/blob/main/README.md#dependencies).
-:::
+<ScriptTools />
 
 ### Init a Script Project
 

--- a/website/docs/script/js-script.mdx
+++ b/website/docs/script/js-script.mdx
@@ -110,12 +110,20 @@ understanding.
 
 The first step is to create a new Script project. We use [ckb-script-templates](https://github.com/cryptape/ckb-script-templates) for this purpose. You will need the following dependencies:
 
-- `git`, `make`, `sed`, `bash`, `sha256sum` and others Unix utilities
-- `Rust` with `riscv64` target installed: `rustup target add riscv64imac-unknown-none-elf`
-- `Clang 16+`
-- `cargo-generate`: You can install this via `cargo install cargo-generate`
+:::info Tools You Need
 
-If you encounter any problems with these dependencies, refer to the [ReadMe](https://github.com/cryptape/ckb-script-templates?tab=readme-ov-file#dependencies) for installation details.
+- [git](https://git-scm.com/), [make](https://www.tutorialspoint.com/unix_commands/make.htm), [sed](https://www.gnu.org/software/sed/), [bash](https://www.gnu.org/software/bash/), [sha256sum](https://linux.die.net/man/1/sha256sum) and others Unix utilities.
+- [Rust](https://www.rust-lang.org/) with `riscv64 target`: `rustup target add riscv64imac-unknown-none-elf`
+- [Clang 16+](https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html)
+- [Cargo-generate](https://github.com/cargo-generate/cargo-generate)
+  - Debian / Ubuntu: ` wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo./llvm.sh 16 && rm llvm.sh`
+  - Fedora 39+: `sudo dnf -y install clang`
+  - Archlinux: `sudo pacman --noconfirm -Syu clang`
+  - MacOS (with [Homebrew](https://brew.sh/)): `brew install llvm@16`
+  - Windows (with [Scoop](https://scoop.sh/)): `scoop install llvm yasm`
+
+Check out the `ckb-script-templates` for more [details](https://github.com/cryptape/ckb-script-templates/blob/main/README.md#dependencies).
+:::
 
 ### Init a Script Project
 


### PR DESCRIPTION
Description:
- Fix the broken link around ckb-script-templates
- Make the tools you need for script development consistent across different pages
![Screenshot 2024-05-14 at 12 09 49 PM](https://github.com/nervosnetwork/docs.nervos.org/assets/140578792/09464737-272c-4729-91cc-8f3137f7c950)

- Use "info" instead of "note" when describing tools or versions