### PR TITLE
chore: ccc mini version

### DIFF
--- a/website/docs/getting-started/installation.mdx
+++ b/website/docs/getting-started/installation.mdx
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 This installation guide provides a step-by-step setup of all essential tools needed for completing every tutorial across the documentation.
 
-## CKB Basic Developement
+## CKB Basic Development
 
 This section covers the essential tools you need to develop CKB applications, including setting up the local development environment and JavaScript SDK.
 
@@ -22,9 +22,10 @@ OffCKB sets up a local CKB Devnet, allowing you to test dApps without connecting
 npm install -g @offckb/cli
 ```
 
-### 2. CCC (≥v0.1.0-alpha.4)
+### 2. CCC (≥v0.0.14-alpha.0)
 
-CCC is the JavaScript SDK used for interacting with CKB, helping you build transactions and interact with the blockchain. We recommend using **≥v0.1.0-alpha.4**.
+CCC is the JavaScript SDK used for interacting with CKB, helping you build transactions and interact with the blockchain.
+This website's documentation assumes a minimum version of **≥v0.0.14-alpha.0**.
 
 ```mdx-code-block
 <Tabs>

--- a/website/src/components/TutorialHeader/index.tsx
+++ b/website/src/components/TutorialHeader/index.tsx
@@ -36,11 +36,11 @@ const DAPP_HEADER: JSX.Element[] = [
   <div key="ccc">
     JavaScript SDK:{" "}
     <Link
-      to="/docs/getting-started/installation-guide#2-ccc-v010-alpha4"
+      to="/docs/getting-started/installation-guide#2-ccc-v0014-alpha0"
       target="_blank"
       rel="noopener noreferrer"
     >
-      CCC (≥v0.1.0-alpha.4)
+      CCC (≥v0.0.14-alpha.0)
     </Link>
   </div>,
 ];


### PR DESCRIPTION
change the ccc mini version to `v0.0.14-alpha.0` since our `examples` use ccc `v0.0.14-alpha.0`. Later, we should upgrade the version in examples and then bump the required minimal version in docs.