### PR TITLE
fix: temporarily remove proxy and onion related node config

### DIFF
--- a/website/docs/node/node-configuration.mdx
+++ b/website/docs/node/node-configuration.mdx
@@ -36,7 +36,6 @@ ckb.toml
 This article covers the following configuration topics:
 
 - [Light client support and WSS access](#light-client-support--wss-access)
-- [Proxy and onion routing support](#proxy-and-onion-routing-support)
 - [Fee estimator](#fee-estimator)
 - [Run multiple nodes](#run-multiple-nodes)
 
@@ -253,55 +252,6 @@ bootnodes = ["/dns4/ckb.example.com/tcp/443/wss/p2p/<PeerID>"]
 3. Start the second node
 
 Start the second node and check the logs. If it begins syncing blocks successfully, your WSS setup is complete.
-
-## Proxy and Onion Routing Support
-
-CKB supports advanced networking configurations for users who want to:
-
-- Preserve privacy by hiding their node’s IP address
-- Route traffic through a proxy (e.g., SOCKS5)
-- Expose their node on the Tor network using an `.onion` address
-
-These are useful for censorship resistance, secure relayers, and privacy-focused deployments.
-
-### ProxyConfig
-
-The `[network.proxy]`section allows your node to route outbound P2P connections through a SOCKS5 proxy, such as the one provided by a Tor server.
-
-```bash
-[network.proxy]
-proxy_url = "socks5://127.0.0.1:9050"
-proxy_random_auth = true
-```
-
-- `proxy_url`: The URL of your SOCKS5 proxy.
-  - Default Tor proxy: `socks5://127.0.0.1:9050`
-  - If you're running a local Tor server, this will work out of the box.
-- `proxy_random_auth` : When enabled, CKB generates a random username and password per connection, improving privacy (like Tor's `IsolateSOCKSAuth`).
-  - Recommended for Tor usage
-  - If using a non-Tor proxy that supports but doesn’t require authentication, you may need to set this to `false` to avoid connection failures.
-
-### OnionConfig
-
-The `[network.onion]`section in `ckb.toml` allows your node to act as a **Tor hidden service**, accepting inbound connections over the `.onion` network.
-
-```bash
-[network.onion]
-listen_on_onion = true
-onion_service_target = "127.0.0.1:8115"
-onion_server = "127.0.0.1:9050"
-tor_controller = "127.0.0.1:9051"
-tor_password = ""
-```
-
-- `listen_on_onion`: Enables listening for incoming connections over the Tor network. If `true`, your node will publish a `.onion` address and accept Tor traffic.
-- `onion_service_target`: The local address your Onion service will forward to — usually your CKB node’s P2P port. It sets to `127.0.0.1:8115` by default.
-- `onion_server`: SOCKS5 proxy used to connect to other `.onion` addresses.
-  - If unset, CKB will use the proxy defined in `[network.proxy]`.
-- `tor_controller`: The address of the Tor ControlPort, which CKB uses to register or manage Onion services. It sets to `127.0.0.1:9051` by default.
-- `tor_password`: Password used to authenticate with the Tor ControlPort.
-  - You can leave it empty if the Tor ControlPort allows unauthenticated access (not recommended for production).
-  - The password must match the `HashedControlPassword` in your `torrc` file.
 
 ## Fee Estimator
 


### PR DESCRIPTION
Description:
Temporarily removed the proxy & onion section until https://github.com/nervosnetwork/ckb/pull/4733 is merged, which adds the related config options to `ckb.toml`.