### PR TITLE
fix: tooltip clipping issue

### DIFF
--- a/website/src/components/Tooltip/index.tsx
+++ b/website/src/components/Tooltip/index.tsx
@@ -1,7 +1,8 @@
+import { createPortal } from "react-dom";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect, useRef, useState } from "react";
 import keyTerms from "./key-terms.json";
 
 interface TooltipProps {
@@ -18,7 +19,14 @@ interface GlossaryTerms {
 
 const terms: GlossaryTerms = keyTerms as GlossaryTerms;
 
-const Tooltip: React.FC<TooltipProps> = ({ className, children }) => {
+// simple ID generator for aria-describedby
+let tooltipIdCounter = 0;
+function getUniqueId() {
+  tooltipIdCounter += 1;
+  return `tooltip-${tooltipIdCounter}`;
+}
+
+export default function Tooltip({ className, children }: TooltipProps) {
   if (!children) return null;
 
   const term = children.toString();
@@ -32,18 +40,136 @@ const Tooltip: React.FC<TooltipProps> = ({ className, children }) => {
   }
 
   const glossaryEntry = terms[childText] || terms[normalizedTerm];
-  const tooltipContent = glossaryEntry.content || "";
+  const tooltipContent = glossaryEntry?.content || "";
   const tooltipLink =
-    glossaryEntry.link || `/docs/tech-explanation/glossary#${normalizedTerm}`;
+    glossaryEntry?.link || `/docs/tech-explanation/glossary#${normalizedTerm}`;
+
+  const spanRef = useRef<HTMLSpanElement | null>(null);
+  const lastIndexRef = useRef(0);
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState({ top: 0, left: 0 });
+  const tipIdRef = useRef(getUniqueId());
+
+  const OFFSET = 8;
+
+  function pickFragmentRect(el: HTMLElement, clientX: number, clientY: number) {
+    const rects = Array.from(el.getClientRects());
+    if (!rects.length) return null;
+    const hitIndex = rects.findIndex(
+      (r) => clientY >= r.top && clientY <= r.bottom
+    );
+    if (hitIndex >= 0) {
+      lastIndexRef.current = hitIndex;
+      return rects[hitIndex];
+    }
+    let best = 0,
+      bestDist = Infinity;
+    rects.forEach((r, i) => {
+      const dy = clientY < r.top ? r.top - clientY : clientY - r.bottom;
+      const dx = clientX < r.left ? r.left - clientX : clientX - r.right;
+      const d = dy * dy + dx * dx;
+      if (d < bestDist) {
+        bestDist = d;
+        best = i;
+      }
+    });
+    lastIndexRef.current = best;
+    return rects[best];
+  }
+
+  const updateFromPointer = (e: React.PointerEvent) => {
+    const el = spanRef.current;
+    if (!el) return;
+    const rect = pickFragmentRect(el, e.clientX, e.clientY);
+    if (!rect) return;
+    setPos({
+      top: rect.top + window.scrollY - OFFSET,
+      left: rect.left + window.scrollX,
+    });
+  };
+
+  const onEnter = (e: React.PointerEvent) => {
+    updateFromPointer(e);
+    setOpen(true);
+  };
+  const onMove = (e: React.PointerEvent) => {
+    if (open) updateFromPointer(e);
+  };
+  const onLeave = () => setOpen(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const h = () => {
+      const el = spanRef.current;
+      if (!el) return;
+      const rects = el.getClientRects();
+      const r = rects[lastIndexRef.current] || rects[0];
+      if (r)
+        setPos({
+          top: r.top + window.scrollY - OFFSET,
+          left: r.left + window.scrollX,
+        });
+    };
+    window.addEventListener("resize", h);
+    window.addEventListener("scroll", h, true);
+    return () => {
+      window.removeEventListener("resize", h);
+      window.removeEventListener("scroll", h, true);
+    };
+  }, [open]);
+
+  if (!tooltipContent) {
+    return (
+      <Link
+        to={tooltipLink}
+        className={clsx(styles.tooltipContainer, className)}
+      >
+        {children}
+      </Link>
+    );
+  }
 
   return (
-    <Link to={tooltipLink} className={clsx(styles.tooltipContainer, className)}>
-      {children}
-      {tooltipContent && (
-        <div className={styles.tooltipContent}>{tooltipContent}</div>
-      )}
-    </Link>
-  );
-};
+    <>
+      <Link
+        to={tooltipLink}
+        className={clsx(styles.tooltipContainer, className)}
+      >
+        <span
+          ref={spanRef}
+          className={styles.tooltipHit}
+          onPointerEnter={onEnter}
+          onPointerMove={onMove}
+          onPointerLeave={onLeave}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          aria-describedby={open ? tipIdRef.current : undefined}
+        >
+          {children}
+        </span>
+      </Link>
 
-export default Tooltip;
+      {createPortal(
+        <div
+          id={tipIdRef.current}
+          role="tooltip"
+          className={clsx(
+            styles.tooltipPortal,
+            open && styles.tooltipPortalOpen
+          )}
+          style={{
+            position: "absolute",
+            top: pos.top,
+            left: pos.left,
+            transform: "translateY(-100%)",
+          }}
+          onPointerEnter={() => setOpen(true)}
+          onPointerLeave={() => setOpen(false)}
+        >
+          {tooltipContent}
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}

--- a/website/src/components/Tooltip/styles.module.css
+++ b/website/src/components/Tooltip/styles.module.css
@@ -14,12 +14,13 @@
   color: var(--text-inverse);
   border-radius: 4px;
   padding: 0.5rem 1rem;
-  position: absolute;
-  z-index: 9999;
+  position: fixed;
   max-width: 400px;
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
+  pointer-events: none;
 }
 .tooltipPortalOpen {
   opacity: 1;
+  pointer-events: auto;
 }

--- a/website/src/components/Tooltip/styles.module.css
+++ b/website/src/components/Tooltip/styles.module.css
@@ -1,32 +1,25 @@
 @import "@css/customVariables.css";
 
 .tooltipContainer {
-  position: relative;
-  display: inline-block;
   color: var(--text-secondary);
   cursor: pointer;
   text-decoration: underline !important;
   text-decoration-style: dotted !important;
   text-underline-offset: 4px !important;
+  pointer-events: auto;
 }
 
-.tooltipContent {
-  visibility: hidden;
+.tooltipPortal {
   background-color: var(--surface-inverse);
   color: var(--text-inverse);
   border-radius: 4px;
   padding: 0.5rem 1rem;
   position: absolute;
-  z-index: 1;
-  bottom: 120%;
-  left: 0;
-  margin-left: -60px;
-  width: 400px;
+  z-index: 9999;
+  max-width: 400px;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity 0.2s ease-in-out;
 }
-
-.tooltipContainer:hover .tooltipContent {
-  visibility: visible;
+.tooltipPortalOpen {
   opacity: 1;
 }


### PR DESCRIPTION
Fix: https://github.com/nervosnetwork/docs.nervos.org/issues/638
Description: 
1. Render tooltip with createPortal so it’s no longer clipped by parent containers.
2. Assign a unique id to each tooltip and reference it via aria-describedby for screen reader support.