### PR TITLE
docs: fix grammar errors and typos in MDX files

### DIFF
--- a/website/docs/dapp/create-token.mdx
+++ b/website/docs/dapp/create-token.mdx
@@ -19,7 +19,7 @@ import ExampleLink from "@components/ExampleLink";
 
 Unlike [ERC20(Ethereum)](https://eips.ethereum.org/EIPS/eip-20) and [BRC20(Bitcoin)](https://www.brc-20.io/), CKB uses a unique way to build custom tokens based on its UTXO-like <Tooltip>Cell Model</Tooltip>.
 
-In CKB, custom tokens are called User-Defined Tokens (UDTs). CKB defines a minimal standard for UDT called [xUDT(extensible UDT)](/docs/assets-token-standards/xudt). In this tutorial, you will learn how to issue custom tokens using the pre-deployed `xUDT Script`.
+In CKB, custom tokens are called User-Defined Tokens (UDTs). CKB defines a minimal standard for UDTs called [xUDT(extensible UDT)](/docs/assets-token-standards/xudt). In this tutorial, you will learn how to issue custom tokens using the pre-deployed `xUDT Script`.
 
 Steps to Issue a Custom Token with xUDT:
 
@@ -39,7 +39,7 @@ To get started with the tutorial dApp, download or clone the <ExampleLink path="
 
 <SetupProject imageSrc="img/dapps/issue-token-dapp.jpg" />
 
-## Behind the Scene
+## Behind the Scenes
 
 ### Issuing Custom Token
 
@@ -63,7 +63,7 @@ export async function issueToken(privKey: string, amount: string) {
 This function accepts two parameters:
 
 - `privKey`: The private key of the issuer
-- `amount`: The amount of token
+- `amount`: The amount of tokens
 
 Note that we aim to create an output Cell whose <Tooltip>Type Script</Tooltip> is an xUDT Script. The args of this xUDT Script are the issuer's Lock Script Hash, which is why we include the following lines of code:
 
@@ -97,7 +97,7 @@ Next, to complete our `issueToken` function, we just use the `helpers.Transactio
 ...
 ```
 
-Lastly, we do the signing and sending transaction:
+Lastly, we do the signing and sending of the transaction:
 
 ```ts
 const txHash = await signer.sendTransaction(tx);
@@ -173,7 +173,7 @@ const tx = ccc.Transaction.from({
 await tx.completeInputsByUdt(signer, xUdtType);
 ```
 
-Notice that If there is any token amount remaining, we need to return the change amount along with change capacities to the sender.
+Notice that if there is any token amount remaining, we need to return the change amount along with change capacities to the sender.
 
 ```ts
 const balanceDiff =

--- a/website/docs/how-tos/how-to-sign-a-tx.mdx
+++ b/website/docs/how-tos/how-to-sign-a-tx.mdx
@@ -105,7 +105,7 @@ For example, consider the following inputs:
 inputs = [g1, g2, g1]
 ```
 
-Here are three inputs, where the gN notation represents the group. `inputs[0]` and `inputs[2]` share the same group **g1**, while `inputs[1]` is in a different group **g2**. CKB runs the Lock Script on **g1** and **g2** separately. Understanding that the same `script_hash` implies identical lock fields of inputs, thus requiring only one signature per group.
+Here are three inputs, where the gN notation represents the group. `inputs[0]` and `inputs[2]` share the same group **g1**, while `inputs[1]` is in a different group **g2**. CKB runs the Lock Script on **g1** and **g2** separately. Understand that the same `script_hash` implies identical lock fields of inputs, thus requiring only one signature per group.
 
 The default locks, such as P2SH and multisig, assume there is a <Tooltip>witness</Tooltip> for each input group. The witness contains the signature and the default locks read the signature from the index of the first input. For **g1**, the signature is read from `witnesses[0]`, while for **g2**, from `witnesses[1]`.
 
@@ -141,7 +141,7 @@ The default P2PKH and the multisig Scripts require user to use `WitnessArgs` on 
 
 In CKB, `witnesses` is extended to allow users to include any one-time data necessary solely for the transaction’s verification process. However, this flexibility brings a problem, a transaction's Lock Script and Type Script may require different data from the same witness, there is a risk that neither script’s requirement can be met at the same time, potentially causing the transaction permanently locked.
 
-To dismiss this potential conflict, `WitnessArgs` is introduced to allow Lock Script and Type Script to read data from different fields in the `WitnessArgs`.
+To resolve this potential conflict, `WitnessArgs` is introduced to allow Lock Script and Type Script to read data from different fields in the `WitnessArgs`.
 
 :::
 

--- a/website/docs/tech-explanation/glossary.md
+++ b/website/docs/tech-explanation/glossary.md
@@ -26,7 +26,7 @@ A kind of basic object in distributed ledger used to keep the balance and other 
 ### Address
 
 A label consists of string of letters and numbers that anonymously represents user's identity on chain. Crypto assets can be sent to and/or from addresses.
-CKB address packages [Lock Script](#lock-script) into a single line, verifiable, and human read friendly format. A single public-private key pair can generate multiple Lock Scripts, consequently multiple addresses.
+CKB address packages [Lock Script](#lock-script) into a single line, verifiable, and human-readable format. A single public-private key pair can generate multiple Lock Scripts, consequently multiple addresses.
 
 #### Synonyms
 
@@ -189,7 +189,7 @@ The maximum space (in bytes) that a Cell can occupy on the Nervos CKB.
 
 ### Cell
 
-Cells are the primary state units in CKB, within them users can include arbitrary states. All data on Nervos CKB is stored in Cells.
+Cells are the primary state units in CKB, within which users can include arbitrary states. All data on Nervos CKB is stored in Cells.
 
 A Cell has 4 fields: `capacity`, `data`, `type` and `lock`.
 
@@ -596,7 +596,7 @@ The sender of a transaction often includes a fee to the network for processing t
 
 A tip per byte that a user offers to the miners for including his transaction in a block on the blockchain.
 
-This is a same concept to Bitcoin's [Fee Rate(often spelled feerate)](https://en.bitcoin.it/wiki/Miner_fees#Feerates).
+This is the same concept as Bitcoin's [Fee Rate(often spelled feerate)](https://en.bitcoin.it/wiki/Miner_fees#Feerates).
 
 #### See Also
 

--- a/website/docs/tech-explanation/glossary.md
+++ b/website/docs/tech-explanation/glossary.md
@@ -596,7 +596,7 @@ The sender of a transaction often includes a fee to the network for processing t
 
 A tip per byte that a user offers to the miners for including his transaction in a block on the blockchain.
 
-This is the same concept as Bitcoin's [Fee Rate(often spelled feerate)](https://en.bitcoin.it/wiki/Miner_fees#Feerates).
+This is the same concept as Bitcoin's [Fee Rate (often spelled feerate)](https://en.bitcoin.it/wiki/Miner_fees#Feerates).
 
 #### See Also
 


### PR DESCRIPTION
### What this does
Fixes minor grammar and wordings issues in the rendered MDX documentation. 
### Note
- Just clean ups 
- No components, imports or logics modified 