### PR TITLE
fix: prevent page auto-scrolling to top

### DIFF
--- a/website/src/theme/Navbar/auto-scroll.ts
+++ b/website/src/theme/Navbar/auto-scroll.ts
@@ -49,8 +49,10 @@ export function ensureActiveTabInView() {
 
   // Not visible after restoring scroll, so scroll into view.
   if (!isItemVisibleAfterRestore) {
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
     item.scrollIntoView({ block: "nearest", inline: "nearest" });
-    document.body.scrollTop = document.documentElement.scrollTop = 0;
+    window.scrollTo(scrollX, scrollY);
   }
 
   if (sidebar) {


### PR DESCRIPTION
The MutationObserver on ```#__docusaurus ``` fires ```ensureActiveTabInView()``` on every DOM change, which
  was forcing ```scrollTop = 0 ``` and snapping the page back to the top
 
The fix: save and restore the document scroll position around ```scrollIntoView()``` so only the sidebar scrolls, not the whole page.