### PR TITLE
fix: stop sidebar observer from fighting page scroll

### DIFF
--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -218,6 +218,14 @@ ul.dropdown__menu {
 }
 
 /* Sidebar Menu */
+nav[aria-label="Docs sidebar"] {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+nav[aria-label="Docs sidebar"]::-webkit-scrollbar {
+  display: none;
+}
+
 .menu {
   padding: 1rem 1rem 3rem 1rem !important;
 }

--- a/website/src/theme/Navbar/auto-scroll.ts
+++ b/website/src/theme/Navbar/auto-scroll.ts
@@ -49,8 +49,10 @@ export function ensureActiveTabInView() {
 
   // Not visible after restoring scroll, so scroll into view.
   if (!isItemVisibleAfterRestore) {
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
     item.scrollIntoView({ block: "nearest", inline: "nearest" });
-    document.body.scrollTop = document.documentElement.scrollTop = 0;
+    window.scrollTo(scrollX, scrollY);
   }
 
   if (sidebar) {

--- a/website/src/theme/Navbar/auto-scroll.ts
+++ b/website/src/theme/Navbar/auto-scroll.ts
@@ -4,15 +4,6 @@ export function ensureActiveTabInView() {
   const sidebar = document.querySelector("nav[aria-label='Docs sidebar']");
 
   if (sidebar) {
-    // Hide the scrollbar for better UX
-    // @ts-ignore
-    sidebar.style = `
-      -ms-overflow-style: none;  /* IE and Edge */
-      scrollbar-width: none;  /* Firefox */
-      &::-webkit-scrollbar {
-          display: none;  /* Chrome, Safari and Opera */
-      }
-    `;
     const lastScrollTop = sessionStorage.getItem(SIDEBAR_SCROLL_TOP_KEY);
     if (lastScrollTop !== null) {
       sidebar.scrollTop = parseInt(lastScrollTop, 10);
@@ -36,7 +27,6 @@ export function ensureActiveTabInView() {
   if (sidebar) {
     const itemRect = item.getBoundingClientRect();
     const sidebarRect = sidebar.getBoundingClientRect();
-    // Check if item is visible within the sidebar's viewport
     isItemVisibleAfterRestore =
       itemRect.top >= sidebarRect.top && itemRect.bottom <= sidebarRect.bottom;
   } else {
@@ -60,31 +50,33 @@ export function ensureActiveTabInView() {
       SIDEBAR_SCROLL_TOP_KEY,
       sidebar.scrollTop.toString()
     );
-    // Restore the scrollbar style
-    // @ts-ignore
-    sidebar.style = undefined;
   }
 }
 
-export function observeDocumentChanges() {
-  const observer = new MutationObserver((mutationsList) => {
-    for (const mutation of mutationsList) {
-      if (
-        mutation.type === "childList" ||
-        (mutation.type === "attributes" && mutation.attributeName === "class")
-      ) {
-        ensureActiveTabInView();
-      }
-    }
+export function observeSidebarChanges() {
+  const sidebar = document.querySelector("nav[aria-label='Docs sidebar']");
+  if (!sidebar) {
+    return;
+  }
+
+  let rafId: number | null = null;
+
+  const observer = new MutationObserver(() => {
+    if (rafId !== null) return;
+    rafId = requestAnimationFrame(() => {
+      rafId = null;
+      ensureActiveTabInView();
+    });
   });
 
-  const targetNode = document.getElementById("__docusaurus");
-  if (targetNode) {
-    const config = { attributes: true, childList: true, subtree: true };
-    observer.observe(targetNode, config);
-  }
+  observer.observe(sidebar, {
+    childList: true,
+    subtree: true,
+  });
+
   return () => {
     observer.disconnect();
+    if (rafId !== null) cancelAnimationFrame(rafId);
   };
 }
 

--- a/website/src/theme/Navbar/auto-scroll.ts
+++ b/website/src/theme/Navbar/auto-scroll.ts
@@ -54,9 +54,10 @@ export function ensureActiveTabInView() {
 }
 
 export function observeSidebarChanges() {
-  const sidebar = document.querySelector("nav[aria-label='Docs sidebar']");
+  const label = "Docs sidebar";
+  const sidebar = document.querySelector(`nav[aria-label='${label}']`);
   if (!sidebar) {
-    return;
+    return () => {};
   }
 
   let rafId: number | null = null;

--- a/website/src/theme/Navbar/index.tsx
+++ b/website/src/theme/Navbar/index.tsx
@@ -1,29 +1,29 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import NavbarLayout from "@theme/Navbar/Layout";
 import NavbarContent from "@theme/Navbar/Content";
 import { useLocation } from "@docusaurus/router";
 import {
   ensureActiveTabInView,
-  observeDocumentChanges,
+  observeSidebarChanges,
   subscribeSidebarScroll,
 } from "./auto-scroll";
 
 export default function Navbar(): JSX.Element {
-  const isMounted = useRef(false);
   const location = useLocation();
 
   useEffect(() => {
     ensureActiveTabInView();
+  }, [location.pathname]);
 
+  useEffect(() => {
     const unsubscribeSidebarScroll = subscribeSidebarScroll();
-    const unsubscribeDocumentChanges = observeDocumentChanges();
+    const unsubscribeSidebarChanges = observeSidebarChanges();
 
-    isMounted.current = true;
     return () => {
       unsubscribeSidebarScroll?.();
-      unsubscribeDocumentChanges?.();
+      unsubscribeSidebarChanges?.();
     };
-  }, [location.pathname]);
+  }, []);
 
   return (
     <NavbarLayout>


### PR DESCRIPTION
The MutationObserver from the previous fix was watching the entire `#__docusaurus` root. During normal scrolling, Docusaurus's TOC toggles active classes on heading links — every one of those class changes fired `ensureActiveTabInView()`, which called `scrollIntoView` + `scrollTo` dozens of times per second while you scrolled. The page fought back.

   **What changed:**
   - Observer now watches only the sidebar element, not the whole page — TOC mutations no longer trigger it
   - Debounced with `requestAnimationFrame` so multiple mutations in one frame coalesce into a single call
   - Moved scrollbar-hiding CSS to the stylesheet — the old inline `&::-webkit-scrollbar` syntax never actually worked (needs a real CSS rule, not inline style)
   - Removed the per-call `sidebar.style` set/unset cycle that caused extra DOM mutations and style recalc
   - Split the `useEffect` into route-change vs mount-once so observers aren't torn down and recreated on every navigation"

Attached is the video of the new behaviour 

https://github.com/nervosnetwork/docs.nervos.org/issues/734

[Screencast from 2026-02-12 09-50-47.webm](https://github.com/user-attachments/assets/f899ea9e-b6be-40d7-85a6-3ce9d1be5ef1)

