### PR TITLE
fix: correct mobile wallet card layout on intro-to-wallets

### DIFF
--- a/website/docs/integrate-wallets/intro-to-wallets.mdx
+++ b/website/docs/integrate-wallets/intro-to-wallets.mdx
@@ -21,7 +21,7 @@ When it comes to storing and securing CKB assets, users have various options, in
 
 These wallets listed below offer custody and security services tailored to CKB. For more information, refer to the respective guides for each wallet.
 
-<CardLayout colNum={[3, 2, 2, 2]}>
+<CardLayout colNum={[3, 2, 2, 1]}>
   {walletCardContents.map(({ index, title, href, tags }) => (
     <WalletCard key={index} title={title} href={href} tags={tags} />
   ))}

--- a/website/src/components/WalletCard/styles.module.css
+++ b/website/src/components/WalletCard/styles.module.css
@@ -31,10 +31,12 @@
   display: flex;
   flex-direction: column;
   margin-left: 8px;
+  min-width: 0;
 }
 .title {
   font-size: 1em;
   font-weight: bold;
+  overflow-wrap: anywhere;
 }
 .tags {
   display: flex;


### PR DESCRIPTION
Set the wallet list on /integrate-wallets/intro-to-wallets to one column on extra-small screens to prevent cramped two-column cards.\n\nUpdate WalletCard text container styles to allow shrinking in flex layouts and wrap long names within the card on mobile.