### PR TITLE
fix: add deprecation notices and redirect for lumos removal

### DIFF
--- a/website/docs/script/debug-script.mdx
+++ b/website/docs/script/debug-script.mdx
@@ -126,7 +126,14 @@ Transfer cycles: 764, running cycles: 942
 
 In most case, you want to debug failed transactions instead of successful ones to find out the reasons for the failures.
 
-First, dump the transaction into a local file. Assume you are using a JavaScript SDK to build the transaction,
+:::caution Legacy Example
+
+The following example demonstrates debugging transactions built with the **Lumos SDK**, which is now deprecated.
+If you are using [CCC](/docs/sdk-and-devtool/ccc) or other JavaScript SDKs, the transaction building API will differ.
+
+:::
+
+First, dump the transaction into a local file. Assume you are using the Lumos SDK to build the transaction,
 you can convert the `txSkeleton` type into a JSON file:
 
 ```js

--- a/website/docs/script/rust/rust-debug.mdx
+++ b/website/docs/script/rust/rust-debug.mdx
@@ -126,7 +126,14 @@ Transfer cycles: 764, running cycles: 942
 
 In most case, you want to debug failed transactions instead of successful ones to find out the reasons for the failures.
 
-First, dump the transaction into a local file. Assume you are using a JavaScript SDK to build the transaction,
+:::caution Legacy Example
+
+The following example demonstrates debugging transactions built with the **Lumos SDK**, which is now deprecated.
+If you are using [CCC](/docs/sdk-and-devtool/ccc) or other JavaScript SDKs, the transaction building API will differ.
+
+:::
+
+First, dump the transaction into a local file. Assume you are using the Lumos SDK to build the transaction,
 you can convert the `txSkeleton` type into a JSON file:
 
 ```js

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -206,6 +206,10 @@ const config = {
             from: "/docs/history-and-hard-forks/history-vm-version",
             to: "/docs/script/vm-version",
           },
+          {
+            from: "/docs/sdk-and-devtool/lumos",
+            to: "/docs/sdk-and-devtool/ccc",
+          },
         ],
         createRedirects(existingPath) {
           if (


### PR DESCRIPTION
This PR fixes inconsistencies from the Lumos documentation removal:

## Changes

- **debug-script.mdx** and **rust-debug.mdx**: Added deprecation notice to Lumos-specific debug examples
  - Added \":::caution Legacy Example\" admonition
  - Updated text to explicitly mention \"Lumos SDK\" instead of generic \"JavaScript SDK\"
  - Added link to CCC as the recommended alternative

- **docusaurus.config.js**: Added redirect from \"/docs/sdk-and-devtool/lumos\" to \"/docs/sdk-and-devtool/ccc\"
  - This ensures old bookmarks and external links still work

## Why

The original PR (#751) changed the text from \"Lumos SDK\" to \"a JavaScript SDK\" while keeping Lumos-specific code examples (e.g., \"lumos.helpers.createTransactionFromSkeleton()\"). This created a mismatch where the text suggested generic JavaScript SDK usage but the code was Lumos-specific.

This fix explicitly labels these as legacy examples and redirects the old Lumos docs page to CCC.

---

Relates to #751