### PR TITLE
docs: clarify example clone instructions (#768)

### DIFF
--- a/website/docs/dapp/create-dob.mdx
+++ b/website/docs/dapp/create-dob.mdx
@@ -41,7 +41,14 @@ In this tutorial, you will learn how to build a simple dApp using the Spore SDK 
 
 ### Step 1: Download the Source Code
 
-To get started with the tutorial dApp, download or clone the <ExampleLink path="dApp/create-dob">repository</ExampleLink> and navigate to the appropriate directory.
+To get started with the tutorial dApp, clone the repository and navigate to the appropriate directory:
+
+```bash
+git clone https://github.com/nervosnetwork/docs.nervos.org.git --depth 1
+cd docs.nervos.org/examples/dApp/create-dob
+```
+
+You can also read the full code online or download it <ExampleLink path="dApp/create-dob">here</ExampleLink>.
 
 ### Step 2: Start the Devnet
 

--- a/website/docs/dapp/create-token.mdx
+++ b/website/docs/dapp/create-token.mdx
@@ -33,7 +33,14 @@ While xUDT includes more advanced features, this tutorial focuses on its core co
 
 ### Step 1: Download the Source Code
 
-To get started with the tutorial dApp, download or clone the <ExampleLink path="dApp/xudt">repository</ExampleLink> and navigate to the appropriate directory.
+To get started with the tutorial dApp, clone the repository and navigate to the appropriate directory:
+
+```bash
+git clone https://github.com/nervosnetwork/docs.nervos.org.git --depth 1
+cd docs.nervos.org/examples/dApp/xudt
+```
+
+You can also read the full code online or download it <ExampleLink path="dApp/xudt">here</ExampleLink>.
 
 ### Step 2: Start the Devnet
 

--- a/website/docs/dapp/simple-lock.mdx
+++ b/website/docs/dapp/simple-lock.mdx
@@ -40,7 +40,14 @@ You can find a [Rust implementation of the same hash-lock logic here](/docs/scri
 
 ### Step 1: Download the Source Code
 
-To get started with the tutorial dApp, download or clone the <ExampleLink path="dApp/simple-lock">repository</ExampleLink> and navigate to the appropriate directory.
+To get started with the tutorial dApp, clone the repository and navigate to the appropriate directory:
+
+```bash
+git clone https://github.com/nervosnetwork/docs.nervos.org.git --depth 1
+cd docs.nervos.org/examples/dApp/simple-lock
+```
+
+You can also read the full code online or download it <ExampleLink path="dApp/simple-lock">here</ExampleLink>.
 
 ### Step 2: Start the Devnet
 

--- a/website/docs/dapp/transfer-ckb.mdx
+++ b/website/docs/dapp/transfer-ckb.mdx
@@ -27,7 +27,14 @@ In this tutorial, you will learn how to write a simple dApp to transfer CKB bala
 
 ### Step 1: Download the Source Code
 
-To get started with the tutorial dApp, download or clone the <ExampleLink path="dApp/simple-transfer">repository</ExampleLink> and navigate to the appropriate directory.
+To get started with the tutorial dApp, clone the repository and navigate to the appropriate directory:
+
+```bash
+git clone https://github.com/nervosnetwork/docs.nervos.org.git --depth 1
+cd docs.nervos.org/examples/dApp/simple-transfer
+```
+
+You can also read the full code online or download it <ExampleLink path="dApp/simple-transfer">here</ExampleLink>.
 
 ### Step 2: Start the Devnet
 

--- a/website/docs/dapp/write-message.mdx
+++ b/website/docs/dapp/write-message.mdx
@@ -25,7 +25,14 @@ As you have learned from the first tutorial [Transfer CKB](/docs/dapp/transfer-c
 
 ### Step 1: Download the Source Code
 
-To get started with the tutorial dApp, download or clone the <ExampleLink path="dApp/store-data-on-cell">repository</ExampleLink> and navigate to the appropriate directory.
+To get started with the tutorial dApp, clone the repository and navigate to the appropriate directory:
+
+```bash
+git clone https://github.com/nervosnetwork/docs.nervos.org.git --depth 1
+cd docs.nervos.org/examples/dApp/store-data-on-cell
+```
+
+You can also read the full code online or download it <ExampleLink path="dApp/store-data-on-cell">here</ExampleLink>.
 
 ### Step 2: Start the Devnet
 


### PR DESCRIPTION
Fixes #768. Added explicit `git clone --depth 1` instructions to the dApp tutorial files to make it easier for users with poor network connections to clone the examples.