### PR TITLE
fix(simple-lock): mark @ckb-js-std/core as external to fix build error

### DIFF
--- a/examples/dApp/simple-lock/scripts/build-contract.js
+++ b/examples/dApp/simple-lock/scripts/build-contract.js
@@ -59,6 +59,7 @@ function buildContract(contractName) {
       "--minify",
       "--bundle",
       "--external:@ckb-js-std/bindings",
+      "--external:@ckb-js-std/core",
       "--target=es2022",
       srcFile,
       `--outfile=${outputJsFile}`,


### PR DESCRIPTION
# **Description**
This PR resolves a build failure in the `simple-lock` dApp where `esbuild` was unable to resolve the `@ckb-js-std/core` dependency. By marking this dependency as external in the build script, we allow the bundling process to complete successfully, as this core library is expected to be provided by the runtime environment or handled separately.

## **Ticket Number**
N/A

# **Changes Made**

## **What was the issue?**
Fix the build error encountered when running `pnpm build`:
`✘ [ERROR] Could not resolve "@ckb-js-std/core"`
`The Yarn Plug'n'Play manifest forbids importing "@ckb-js-std/core" here because it's not listed as a dependency of this package`

## **What did you do?**
Updated `scripts/build-contract.js` to include `--external:@ckb-js-std/core` in the `esbuild` arguments. This ensures that `esbuild` does not attempt to bundle this package, resolving the "Could not resolve" error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (changes that do not relate to a fix or feature and don't modify src or test files)

# **Check List**
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR are clear and explain the approach.
- [x] I am making a pull request against the **dev branch** (left side).
- [x] My commit message style matches our requested structure.
- [x] My code additions will not fail code linting checks or unit tests.
- [x] I am only making changes to files I was requested to.

---
# Images
- The live component worked on: **Build Successful** (Verified with `pnpm build`)
<img width="671" height="314" alt="image" src="https://github.com/user-attachments/assets/affde0a3-1629-4f99-a07a-239d0d6331ae" />

- Linting check (run pnpm lint): **Format Successful** (Verified with `pnpm format`, as `lint` script was not present in `package.json`)
<img width="667" height="649" alt="image" src="https://github.com/user-attachments/assets/4c0f7620-35a7-4ebf-b4a0-a6b2b067081e" />
