### PR TITLE
chore: bump version to 2.38.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs.nervos.org",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "Official docs website for Nervos CKB",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Bumps the package version in `website/package.json` from `2.37.0` to `2.38.0`.