### PR TITLE
fix(ci): pin Rust toolchain to 1.94.0 to fix example CI

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -2,9 +2,9 @@ name: Examples
 
 on:
   pull_request:
-    paths: [examples/**, scripts/**]
+    paths: [examples/**, scripts/**, .github/workflows/examples.yaml]
   push:
-    paths: [examples/**, scripts/**]
+    paths: [examples/**, scripts/**, .github/workflows/examples.yaml]
 
 jobs:
   examples:
@@ -13,6 +13,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: '1.94.0'
+          targets: riscv64imac-unknown-none-elf
+          components: rustfmt,clippy
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Problem

The example CI has been failing since May 20, 2026 with the following error in the `ckb-rust-script` step:

```
rustc-LLVM ERROR: Cannot select: ... AtomicLoadAdd<(load store release (s64) on %ir.6)> ...
In function: _ZN5bytes5bytes11shared_drop17h...
```

This happens when compiling the `bytes` crate for `riscv64imac-unknown-none-elf` with `-C target-feature=-a`.

## Root Cause

Rust 1.95.0 (included in the GitHub Actions `ubuntu-24.04` runner image `20260513.135.3`) introduced an LLVM backend regression for RISC-V atomic operations when the atomic extension is disabled via `-C target-feature=-a`.

The CI was passing on May 13 with the previous runner image / Rust version, and started failing as soon as the new image was rolled out.

## Fix

Pin the Rust toolchain to `1.94.0` in the examples CI workflow, which is the last known working version.

## Verification

- Reproduced the failure locally with Rust 1.95.0 and `bytes` 1.11.1
- Verified the build succeeds with Rust 1.94.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)