### PR TITLE
chore: bump version to 2.39.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs.nervos.org",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "Official docs website for Nervos CKB",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
Bump website package version to 2.39.0 for the next docs release.

## Changes
- Update website/package.json version from 2.38.0 to 2.39.0.