### PR TITLE
Repair 7 broken internal and external links

### DIFF
--- a/website/docs/ckb-features/vm-built-for-hackers.md
+++ b/website/docs/ckb-features/vm-built-for-hackers.md
@@ -52,7 +52,7 @@ For example,
 - **Blake2b** is implemented as a library.
 - **Schnorr / BLS / ZK-SNARKs** are implemented as libraries.
 
-Because these algorithms are not embedded in consensus rules, CKB is **crypto-agnostic**. Developers can introduce any new cryptographic primitive whenever they want, without waiting for a hard fork. That’s how CKB is [quantum-resistant](/docs/ckb-features/quantum-resistant) natively and already enabled early experimentation with post-quantum cryptography, such as SPHINCS+.
+Because these algorithms are not embedded in consensus rules, CKB is **crypto-agnostic**. Developers can introduce any new cryptographic primitive whenever they want, without waiting for a hard fork. That’s how CKB is [quantum-resistant](/docs/ckb-features/native-quantum-resistance) natively and already enabled early experimentation with post-quantum cryptography, such as SPHINCS+.
 
 To maintain performance without relying on precompiled operations, CKB-VM uses some optimization techniques:
 

--- a/website/docs/dapp/create-token.mdx
+++ b/website/docs/dapp/create-token.mdx
@@ -17,7 +17,7 @@ import ExampleLink from "@components/ExampleLink";
 
 ## Tutorial Overview
 
-Unlike [ERC20(Ethereum)](https://eips.ethereum.org/EIPS/eip-20) and [BRC20(Bitcoin)](https://www.brc-20.io/), CKB uses a unique way to build custom tokens based on its UTXO-like <Tooltip>Cell Model</Tooltip>.
+Unlike [ERC20(Ethereum)](https://eips.ethereum.org/EIPS/eip-20) and [BRC20(Bitcoin)](https://domo-2.gitbook.io/brc-20-experiment/), CKB uses a unique way to build custom tokens based on its UTXO-like <Tooltip>Cell Model</Tooltip>.
 
 In CKB, custom tokens are called User-Defined Tokens (UDTs). CKB defines a minimal standard for UDTs called [xUDT(extensible UDT)](/docs/assets-token-standards/xudt). In this tutorial, you will learn how to issue custom tokens using the pre-deployed `xUDT Script`.
 

--- a/website/docs/ecosystem-scripts/07-single-use-lock.mdx
+++ b/website/docs/ecosystem-scripts/07-single-use-lock.mdx
@@ -5,7 +5,7 @@ title: Single Use Lock
 
 # Single Use Lock
 
-[Single Use Lock](https://github.com/ckb-devrel/ckb-proxy-locks/tree/main/contracts/single-use-lock) is a [Lock Script](/docs/tech-explanation/lock-script) that allows unlocking only when a specific [OutPoint](/docs/tech-explanation/outpoint) is consumed.
+[Single Use Lock](https://github.com/ckb-devrel/ckb-proxy-locks/tree/main/contracts/single-use-lock) is a [Lock Script](/docs/tech-explanation/lock-script) that allows unlocking only when a specific [OutPoint](/docs/tech-explanation/glossary#outpoint) is consumed.
 
 It is part of the [ckb-proxy-locks](https://github.com/ckb-devrel/ckb-proxy-locks).
 

--- a/website/docs/ecosystem-scripts/14-nostr-lock.mdx
+++ b/website/docs/ecosystem-scripts/14-nostr-lock.mdx
@@ -5,7 +5,7 @@ title: Nostr Lock
 
 # Nostr Lock
 
-Nostr lock is a [Lock Script](/docs/tech-explanation) designed for interoperability with the
+Nostr lock is a [Lock Script](/docs/tech-explanation/lock-script) designed for interoperability with the
 
 [Nostr protocol](https://nostr.com/). It uses Nostr events as witnesses to unlock CKB transactions. It is designed to improve user experience and simplify the development of Nostr-based dApps on CKB.
 

--- a/website/docs/getting-started/how-ckb-works.mdx
+++ b/website/docs/getting-started/how-ckb-works.mdx
@@ -136,7 +136,7 @@ The current `max_block_cycles` in CKB Mainnet `MIRANA` is `3,500,000,000`.
 
 Importantly, there is NO limit on the cycles for an individual transaction or Script; they can consume as many cycles as needed, as along as the entire block stays within the `max_block_cycles`.
 
-To learn more about how cycles are measured for each instruction or syscall, please refer to [Regulate Scripts via Cycle Limits](/docs/scripts/vm-cycle-limits).
+To learn more about how cycles are measured for each instruction or syscall, please refer to [Regulate Scripts via Cycle Limits](/docs/script/vm-cycle-limits).
 
 ---
 

--- a/website/docs/mining/guide.mdx
+++ b/website/docs/mining/guide.mdx
@@ -25,7 +25,7 @@ Nervos uses the Eaglesong hashing algorithm, and mining CKB today requires speci
   width="688"
 />
 
-You can acquire CKB miners from platforms such as [Bitmain Official Store](https://shop.bitmain.com/?coin=CKB), [Wyminer](https://www.wyminer.com/), and [Newegg](https://www.newegg.com/).
+You can acquire CKB miners from platforms such as [Bitmain Official Store](https://shop.bitmain.com/?coin=CKB) and [Newegg](https://www.newegg.com/).
 
 Not all ASICs are created equal—new models are released regularly with different levels of efficiency, noise, and power requirements (110-volt vs. 220-volt). Sites like [ASIC Miner Value](https://www.asicminervalue.com/efficiency/eaglesong) provide detailed specification for Eaglesong miners, while platforms like [f2pool](https://www.f2pool.com/miners?currency_code=ckb) offer revenue comparisons to help you make informed decisions.
 

--- a/website/docs/script/rust/rust-api-ipc.mdx
+++ b/website/docs/script/rust/rust-api-ipc.mdx
@@ -29,7 +29,7 @@ pub fn service(_attr: TokenStream, input: TokenStream) -> TokenStream
 
 ### Example
 
-[A Simplified IPC Solution](/docs/script/ckb-script-ipc#introducing-ckb-script-ipc-a-simplified-ipc-solution)
+[A Simplified IPC Solution](/docs/script/ckb-ipc#ckb-script-ipc-a-simplified-ipc-solution)
 
 To address the complexities of implementing IPC from scratch, we’ve developed [ckb-script-ipc](https://github.com/XuJiandong/ckb-script-ipc), a library that significantly simplifies the process. This library draws inspiration from Google’s [tarpc](https://github.com/google/tarpc) and provides a straightforward, easy-to-use interface for IPC implementation.
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                         
I ran a lychee-based dead-link scan against `website/docs/`, verified each finding against the running Docusaurus site (`yarn start`), and repaired every confirmed-broken link. Result: 7 fixes across 7 files (5 internal, 2 external).                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     


The results were filtered/verified:                                                                                                                                                                                                                                                                                                                   
  - Root-relative /docs/... targets that lychee can't resolve were resolved manually against website/docs/ filesystem layout + Docusaurus frontmatter (id:, slug:) + docusaurus.config.js redirects.                                                                                                                                                     
  - Heading anchors were validated using github-slugger semantics (consecutive whitespace from stripped special chars yields consecutive dashes; explicit {#id} overrides win).                     
  - External URLs that lychee flagged were re-checked with curl to filter HTTP/2 quirks and transient 429s.                                                                                                                                                                                                                                              
                                                                                                           
 Confirmed broken links                                                                                                                                                                                                                                                                                             
                                                       
  Internal                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                         
  1. Stale path — quantum-resistant                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                         
  - Lives on: https://docs.nervos.org/docs/ckb-features/vm-built-for-hackers                                                                                                                                                                                                                                                                             
  - Broken target: https://docs.nervos.org/docs/ckb-features/quantum-resistant → 404                                                                                                                                                                                                                                                                     
  - Fix: /docs/ckb-features/native-quantum-resistance (the page's frontmatter id is native-quantum-resistance; file is quantum-resistance.md                                                                                                                                                                                                                                                                                       
                                                       
  2. Stale path + stale anchor — ckb-script-ipc                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                         
  - Lives on: https://docs.nervos.org/docs/script/rust/rust-api-ipc                                                                                                                                                                                                                                                                                      
  - Broken target: https://docs.nervos.org/docs/script/ckb-script-ipc#introducing-ckb-script-ipc-a-simplified-ipc-solution → 404 (page id is ckb-ipc, not ckb-script-ipc; heading is also different)                                                                                                                                                     
  - Fix: /docs/script/ckb-ipc#ckb-script-ipc-a-simplified-ipc-solution                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                       
  3. Typo — /scripts/ (extra s)                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                         
  - Lives on: https://docs.nervos.org/docs/getting-started/how-ckb-works                                                                                                                                                                                                                                                                                 
  - Broken target: https://docs.nervos.org/docs/scripts/vm-cycle-limits → 404                                                                                                                                                                                                                                                                            
  - Fix: /docs/script/vm-cycle-limits                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                         
                                          
  4. Missing index page — /tech-explanation                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                         
  - Lives on: https://docs.nervos.org/docs/ecosystem-scripts/nostr-lock
  - Broken target: https://docs.nervos.org/docs/tech-explanation → 404 (no index page exists at this path)                                                                                                                                                                                                                                               
  - Fix: /docs/tech-explanation/lock-script (matches the link text "Lock Script")                                                                                                                                                                                                                                                                                           
                                                       
  5. Missing page — /tech-explanation/outpoint                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                         
  - Lives on: https://docs.nervos.org/docs/ecosystem-scripts/single-use-lock                                                                                                                                                                                                                                                                             
  - Broken target: https://docs.nervos.org/docs/tech-explanation/outpoint → 404 (no such page; OutPoint is documented in the glossary)                                                                                                                                                                                                                   
  - Fix: /docs/tech-explanation/glossary#outpoint                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
                                              
  External                                                                                                                                                                                                                                                                                                                                               
                                                       
  6. Dead domain — Wyminer                                                                                                                                                                                                                                                                                                                               
                                                       
 Lives on: https://docs.nervos.org/docs/mining/guide                                                                                                                                                                                                                                                                                                  
  - Broken target: https://www.wyminer.com/ → DNS NXDOMAIN (curl: (6) Could not resolve host)
  - Fix: Removed "Wyminer" from the vendor list ("Bitmain Official Store, Wyminer, and Newegg" → "Bitmain Official Store and Newegg")
                                                                                                                                                                                                                                                                                                         
                                            
  7. Dead domain — brc-20.io                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                         
  - Lives on: https://docs.nervos.org/docs/dapp/create-token                                                                                                                                                                                                                                                                                             
  - Broken target: https://www.brc-20.io/ → DNS NXDOMAIN                                                                                                                                                                                                                                                                                                 
  - Fix: Repointed to the original BRC-20 experiment spec — https://domo-2.gitbook.io/brc-20-experiment/ (authored by domo, who introduced BRC-20)                                                                                                                                                                                                            