### PR TITLE
feat: add docs analytics tracking

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -71,7 +71,7 @@ const config = {
       "@docusaurus/preset-classic",
       {
         gtag: {
-          trackingID: "G-Q42TXTFP46",
+          trackingID: "G-1PH980CNX1",
           anonymizeIP: true,
         },
         docs: {

--- a/website/src/components/AnalyticsTracking/utils.ts
+++ b/website/src/components/AnalyticsTracking/utils.ts
@@ -1,0 +1,11 @@
+export function getSafePagePath(location: {
+  pathname: string;
+  hash?: string;
+}): string {
+  return `${location.pathname}${location.hash || ""}`;
+}
+
+export function getSafeUrl(value: string): string {
+  const url = new URL(value, window.location.href);
+  return `${url.origin}${url.pathname}${url.hash}`;
+}

--- a/website/src/components/LinkClickTracker/index.tsx
+++ b/website/src/components/LinkClickTracker/index.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import { useLocation } from "@docusaurus/router";
+import {
+  getSafePagePath,
+  getSafeUrl,
+} from "@site/src/components/AnalyticsTracking/utils";
+
+const TRACKED_LINK_PROTOCOLS = new Set(["http:", "https:"]);
+
+function getElementLabel(element: HTMLAnchorElement): string {
+  const imageAlt = element.querySelector("img")?.getAttribute("alt");
+  const label =
+    element.innerText ||
+    element.getAttribute("aria-label") ||
+    element.getAttribute("title") ||
+    imageAlt ||
+    "";
+
+  return label.trim().replace(/\s+/g, " ").slice(0, 100);
+}
+
+function getClickArea(element: Element): string {
+  if (element.closest("main article")) {
+    return "article";
+  }
+
+  if (
+    element.closest(
+      "aside, nav[aria-label='Docs sidebar'], .theme-doc-sidebar-container"
+    )
+  ) {
+    return "sidebar";
+  }
+
+  if (element.closest("header, .navbar")) {
+    return "navbar";
+  }
+
+  if (element.closest("footer")) {
+    return "footer";
+  }
+
+  return "page";
+}
+
+export default function LinkClickTracker(): null {
+  const location = useLocation();
+
+  useEffect(() => {
+    const handleLinkClick = (event: MouseEvent) => {
+      const target = event.target;
+
+      if (!(target instanceof Element) || !window.gtag) {
+        return;
+      }
+
+      const link = target.closest<HTMLAnchorElement>("a[href]");
+
+      if (!link) {
+        return;
+      }
+
+      const linkUrl = new URL(link.href, window.location.href);
+
+      if (!TRACKED_LINK_PROTOCOLS.has(linkUrl.protocol)) {
+        return;
+      }
+
+      window.gtag("event", "link_click", {
+        click_area: getClickArea(link),
+        link_text: getElementLabel(link),
+        link_url: getSafeUrl(linkUrl.href),
+        link_domain: linkUrl.hostname,
+        outbound: linkUrl.hostname !== window.location.hostname,
+        page_path: getSafePagePath(location),
+        page_title: document.title,
+      });
+    };
+
+    document.addEventListener("click", handleLinkClick);
+
+    return () => {
+      document.removeEventListener("click", handleLinkClick);
+    };
+  }, [location.pathname, location.hash]);
+
+  return null;
+}

--- a/website/src/components/ScrollDepthTracker/index.tsx
+++ b/website/src/components/ScrollDepthTracker/index.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "@docusaurus/router";
+import { getSafePagePath } from "@site/src/components/AnalyticsTracking/utils";
+
+const SCROLL_MILESTONES = [25, 50, 75, 90, 100];
+
+function getScrollDepth(): number {
+  const element = document.documentElement;
+  const body = document.body;
+  const scrollTop = window.scrollY || element.scrollTop || body.scrollTop || 0;
+  const viewportHeight = window.innerHeight || element.clientHeight;
+  const scrollHeight = Math.max(
+    element.scrollHeight,
+    body.scrollHeight,
+    element.offsetHeight,
+    body.offsetHeight,
+    element.clientHeight,
+    body.clientHeight
+  );
+
+  if (scrollHeight <= viewportHeight) {
+    return 100;
+  }
+
+  return Math.min(
+    100,
+    Math.floor(((scrollTop + viewportHeight) / scrollHeight) * 100)
+  );
+}
+
+export default function ScrollDepthTracker(): null {
+  const location = useLocation();
+  const trackedMilestones = useRef<Set<number>>(new Set());
+  const animationFrame = useRef<number | null>(null);
+
+  useEffect(() => {
+    trackedMilestones.current = new Set();
+
+    const sendScrollDepthEvents = () => {
+      animationFrame.current = null;
+
+      if (!window.gtag) {
+        return;
+      }
+
+      const scrollDepth = getScrollDepth();
+      const pagePath = getSafePagePath(location);
+
+      SCROLL_MILESTONES.forEach((milestone) => {
+        if (
+          scrollDepth >= milestone &&
+          !trackedMilestones.current.has(milestone)
+        ) {
+          trackedMilestones.current.add(milestone);
+          window.gtag("event", "scroll_depth", {
+            percent_scrolled: milestone,
+            page_path: pagePath,
+            page_title: document.title,
+          });
+        }
+      });
+    };
+
+    const scheduleScrollDepthCheck = () => {
+      if (animationFrame.current !== null) {
+        return;
+      }
+
+      animationFrame.current = window.requestAnimationFrame(
+        sendScrollDepthEvents
+      );
+    };
+
+    scheduleScrollDepthCheck();
+    window.addEventListener("scroll", scheduleScrollDepthCheck, {
+      passive: true,
+    });
+    window.addEventListener("resize", scheduleScrollDepthCheck);
+
+    return () => {
+      if (animationFrame.current !== null) {
+        window.cancelAnimationFrame(animationFrame.current);
+      }
+
+      window.removeEventListener("scroll", scheduleScrollDepthCheck);
+      window.removeEventListener("resize", scheduleScrollDepthCheck);
+    };
+  }, [location.pathname, location.hash]);
+
+  return null;
+}

--- a/website/src/components/SearchTermTracker/index.tsx
+++ b/website/src/components/SearchTermTracker/index.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "@docusaurus/router";
+import {
+  getSafePagePath,
+  getSafeUrl,
+} from "@site/src/components/AnalyticsTracking/utils";
+
+const SEARCH_INPUT_SELECTOR = ".aa-Input";
+const SEARCH_EVENT_DELAY = 1000;
+const MAX_SEARCH_TERM_LENGTH = 100;
+const SENSITIVE_SEARCH_PATTERNS = [
+  /\b0x[a-fA-F0-9]{40,}\b/g,
+  /\b[a-fA-F0-9]{64,}\b/g,
+  /\bckb1[023456789acdefghjklmnpqrstuvwxyz]{20,}\b/gi,
+];
+
+function getSafeSearchTerm(value: string): string {
+  return SENSITIVE_SEARCH_PATTERNS.reduce(
+    (searchTerm, pattern) => searchTerm.replace(pattern, "[redacted]"),
+    value.trim().replace(/\s+/g, " ")
+  ).slice(0, MAX_SEARCH_TERM_LENGTH);
+}
+
+export default function SearchTermTracker(): null {
+  const location = useLocation();
+  const trackedSearchTerms = useRef<Set<string>>(new Set());
+  const searchEventTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    const sendSearchTermEvent = (searchTerm: string) => {
+      if (!window.gtag || !searchTerm) {
+        return;
+      }
+
+      const pagePath = getSafePagePath(location);
+      const trackingKey = `${pagePath}:${searchTerm.toLowerCase()}`;
+
+      if (trackedSearchTerms.current.has(trackingKey)) {
+        return;
+      }
+
+      trackedSearchTerms.current.add(trackingKey);
+      window.gtag("event", "view_search_results", {
+        search_term: searchTerm,
+        page_path: pagePath,
+        page_title: document.title,
+      });
+    };
+
+    const handleSearchInput = (event: Event) => {
+      const target = event.target;
+
+      if (
+        !(target instanceof HTMLInputElement) ||
+        !target.matches(SEARCH_INPUT_SELECTOR)
+      ) {
+        return;
+      }
+
+      const searchTerm = getSafeSearchTerm(target.value);
+
+      if (searchEventTimer.current !== null) {
+        window.clearTimeout(searchEventTimer.current);
+      }
+
+      searchEventTimer.current = window.setTimeout(() => {
+        sendSearchTermEvent(searchTerm);
+      }, SEARCH_EVENT_DELAY);
+    };
+
+    const handleSearchSelection = (event: MouseEvent | KeyboardEvent) => {
+      const target = event.target;
+
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      if (
+        event instanceof KeyboardEvent &&
+        (event.key !== "Enter" || !target.matches(SEARCH_INPUT_SELECTOR))
+      ) {
+        return;
+      }
+
+      const selectedLink =
+        event instanceof MouseEvent
+          ? target.closest<HTMLAnchorElement>(".aa-ItemLink")
+          : document.querySelector<HTMLAnchorElement>(
+              ".aa-Item[aria-selected='true'] .aa-ItemLink, .aa-Item[aria-current='true'] .aa-ItemLink, .aa-ItemLink"
+            );
+      const searchInput = document.querySelector<HTMLInputElement>(
+        SEARCH_INPUT_SELECTOR
+      );
+      const searchTerm = getSafeSearchTerm(searchInput?.value || "");
+
+      if (!selectedLink || !window.gtag || !searchTerm) {
+        return;
+      }
+
+      window.gtag("event", "select_search_result", {
+        search_term: searchTerm,
+        page_path: getSafePagePath(location),
+        page_title: document.title,
+        link_url: getSafeUrl(selectedLink.href),
+      });
+    };
+
+    document.addEventListener("input", handleSearchInput);
+    document.addEventListener("click", handleSearchSelection);
+    document.addEventListener("keydown", handleSearchSelection);
+
+    return () => {
+      if (searchEventTimer.current !== null) {
+        window.clearTimeout(searchEventTimer.current);
+      }
+
+      document.removeEventListener("input", handleSearchInput);
+      document.removeEventListener("click", handleSearchSelection);
+      document.removeEventListener("keydown", handleSearchSelection);
+    };
+  }, [location.pathname, location.hash]);
+
+  return null;
+}

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,0 +1,15 @@
+import type { Props } from "@theme/Root";
+import LinkClickTracker from "@site/src/components/LinkClickTracker";
+import SearchTermTracker from "@site/src/components/SearchTermTracker";
+import ScrollDepthTracker from "@site/src/components/ScrollDepthTracker";
+
+export default function Root({ children }: Props): JSX.Element {
+  return (
+    <>
+      <LinkClickTracker />
+      <SearchTermTracker />
+      <ScrollDepthTracker />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Update GA4 tracking for the new Nervos Docs property and instrument docs-specific analytics events requested by marketing.

## Changes
- Update the GA measurement ID
- Track scroll-depth milestones per page
- Track local docs search terms and selected search results
- Track link clicks with sanitized destination and page metadata
- Add shared helpers to avoid sending query strings in custom analytics params
