### PR TITLE
docs: update README release process — restrict master branch to merge-only and require approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,21 @@ If you run into an issue on our documentation website you can contact us on [Ner
 
 ### Release
 
-Production release should be on the master branch. 
+Production release should be on the master branch.
 
 Please follow the steps below:
 
 1. Create a new PR that bumps the version in the `package.json` under `/website`
 2. Merge the PR on `develop` branch
 3. Create a new PR from `develop` that targeting on the `master` branch
-4. Merge the PR into `master` branch
-5. Create a new tag and release on github targeting on the master branch
-6. The release content should include description of changes following 3 sections:
+4. Obtain at least one approval before merging the PR into `master` branch
+5. Merge the PR into `master` branch using **regular merge only**; squash merge and rebase merge are not allowed
+6. Create a new tag and release on github targeting on the master branch
+7. The release content should include description of changes following 3 sections:
    - New Content
    - Fixes
    - Others
-7. Example release content: https://github.com/nervosnetwork/docs.nervos.org/releases/tag/v2.35.0 
+8. Example release content: https://github.com/nervosnetwork/docs.nervos.org/releases/tag/v2.35.0 
 
 ### Develop
 


### PR DESCRIPTION
This PR updates the Release section in the README to clarify merge strategy restrictions and approval requirements.

### Changes
- Added a step to obtain at least one approval before merging a PR into the `master` branch.
- Explicitly stated that only **regular merge** is allowed when merging into `master`; squash merge and rebase merge are prohibited.

These additions help ensure a consistent and auditable release history on the production branch.