### PR TITLE
docs: make Rust SDK parse address example runnable

### DIFF
--- a/website/docs/sdk-and-devtool/rust.mdx
+++ b/website/docs/sdk-and-devtool/rust.mdx
@@ -200,15 +200,30 @@ println!("address: {}", address.to_string());
 
 In the world of CKB, a <Tooltip>Lock Script</Tooltip> can be represented as an address. It is possible to parse an address from an encoded string and then obtain its network and Script.
 
+If you are testing this inside a new `cargo new --bin` project, add these dependencies to `Cargo.toml` and place the code inside `src/main.rs`.
+
+```bash title='Cargo.toml'
+[dependencies]
+ckb-sdk = "3.7.0"
+ckb-types = "0.200.0"
+```
+
 ```rust
 use ckb_sdk::types::Address;
 use ckb_types::packed::Script;
 use std::str::FromStr;
 
-let addr_str = "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqgvf0k9sc40s3azmpfvhyuudhahpsj72tsr8cx3d";
-let addr = Address::from_str(addr_str).unwrap();
-let _network = addr.network();
-let _script: Script = addr.payload().into();
+fn main() {
+    let addr_str = "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqvwg2cen8extgq8s5puft8vf40px3f599cytcyd8";
+
+    let addr = Address::from_str(addr_str).expect("valid CKB address");
+    let network = addr.network();
+    let script: Script = addr.payload().into();
+
+    println!("Address: {}", addr);
+    println!("Network: {:?}", network);
+    println!("Lock Script: {:?}", script);
+}
 ```
 
 :::note


### PR DESCRIPTION
## Summary

This PR updates the Rust SDK `Parse Address` example to make it easier to run in a fresh `cargo new --bin` project.

While testing the example, I noticed two small issues that may confuse new users:

1. The snippet uses `let` statements, which need to be placed inside `fn main()` when copied into `src/main.rs`.
2. The example imports `ckb_types::packed::Script`, so `ckb-types` should be listed as a direct dependency in `Cargo.toml`.

## Changes

- Wrap the parse-address example in a complete `fn main()`.
- Add `ckb-types` to the dependency snippet.
- Use a runnable testnet/devnet-style address example.
- Add a short note explaining where to place the code when testing locally.

## Tested

I tested the updated example in a fresh Rust binary project:

```bash
cargo new --bin ckb-rust-example
cd ckb-rust-example
cargo run

## Output
Address: ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqvwg2cen8extgq8s5puft8vf40px3f599cytcyd8
Network: Testnet
Lock Script: Script(0x490000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce801140000008e42b1999f265a0078503c4acec4d5e134534297)