### PR TITLE
feat: update GA tracking events

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,6 +7,8 @@ const darkCodeTheme = require("./src/prism/dark");
 
 const repoBranch =
   process.env.VERCEL_GIT_COMMIT_REF || process.env.DEPLOY_BRANCH || "master";
+const enableGtag =
+  process.env.VERCEL_ENV === "production" || process.env.ENABLE_GTAG === "true";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -28,7 +30,7 @@ const config = {
   favicon: "img/favicon.png",
   customFields: {
     oldDocSiteUrl: "https://docs-old.nervos.org",
-    gaGtag: true,
+    gaGtag: enableGtag,
     disableHeaderTitle: true,
     socialLinks: [
       {
@@ -70,10 +72,14 @@ const config = {
     [
       "@docusaurus/preset-classic",
       {
-        gtag: {
-          trackingID: "G-1PH980CNX1",
-          anonymizeIP: true,
-        },
+        ...(enableGtag
+          ? {
+              gtag: {
+                trackingID: "G-1PH980CNX1",
+                anonymizeIP: true,
+              },
+            }
+          : {}),
         docs: {
           path: "./docs",
           breadcrumbs: false,

--- a/website/src/components/AnalyticsTracking/utils.ts
+++ b/website/src/components/AnalyticsTracking/utils.ts
@@ -9,3 +9,215 @@ export function getSafeUrl(value: string): string {
   const url = new URL(value, window.location.href);
   return `${url.origin}${url.pathname}${url.hash}`;
 }
+
+type AnalyticsEventParams = Record<
+  string,
+  string | number | boolean | null | undefined
+>;
+
+function isLocalAnalyticsHost(): boolean {
+  return (
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1" ||
+    window.location.hostname === "::1"
+  );
+}
+
+export function getCurrentPagePath(): string {
+  return `${window.location.pathname}${window.location.hash || ""}`;
+}
+
+export function sendAnalyticsEvent(
+  eventName: string,
+  params: AnalyticsEventParams
+): void {
+  if (
+    typeof window === "undefined" ||
+    typeof window.gtag !== "function" ||
+    isLocalAnalyticsHost()
+  ) {
+    return;
+  }
+
+  window.gtag(
+    "event",
+    eventName,
+    Object.fromEntries(
+      Object.entries(params).filter(([, value]) => value !== undefined)
+    )
+  );
+}
+
+export function getLlmsFileName(value: string): string | undefined {
+  const url = new URL(value, window.location.href);
+  const fileName = url.pathname.split("/").pop();
+
+  if (fileName === "llms.txt" || fileName === "llms-full.txt") {
+    return fileName;
+  }
+
+  return undefined;
+}
+
+export function getLlmsFileNameFromText(value: string): string | undefined {
+  const hasLlms = /\/llms\.txt\b|https?:\/\/[^\s]+\/llms\.txt\b/.test(value);
+  const hasLlmsFull =
+    /\/llms-full\.txt\b|https?:\/\/[^\s]+\/llms-full\.txt\b/.test(value);
+
+  if (hasLlms && hasLlmsFull) {
+    return "multiple";
+  }
+
+  if (hasLlmsFull) {
+    return "llms-full.txt";
+  }
+
+  if (hasLlms) {
+    return "llms.txt";
+  }
+
+  return undefined;
+}
+
+const DOC_DESTINATION_CATEGORIES: Array<{
+  destination_category: string;
+  prefixes: string[];
+}> = [
+  {
+    destination_category: "getting_started",
+    prefixes: [
+      "getting-started/how-ckb-works",
+      "getting-started/quick-start",
+      "getting-started/ckb-networks",
+      "getting-started/rpcs",
+    ],
+  },
+  {
+    destination_category: "sdk_devtools",
+    prefixes: ["sdk-and-devtool"],
+  },
+  {
+    destination_category: "ai_agents",
+    prefixes: ["ai-agents"],
+  },
+  {
+    destination_category: "build_dapp",
+    prefixes: ["dapp"],
+  },
+  {
+    destination_category: "integrate_wallets",
+    prefixes: ["integrate-wallets"],
+  },
+  {
+    destination_category: "serialization",
+    prefixes: ["serialization"],
+  },
+  {
+    destination_category: "how_tos",
+    prefixes: ["how-tos"],
+  },
+  {
+    destination_category: "script",
+    prefixes: ["script"],
+  },
+  {
+    destination_category: "script",
+    prefixes: ["ecosystem-scripts"],
+  },
+  {
+    destination_category: "what_makes_ckb_unique",
+    prefixes: ["ckb-features"],
+  },
+  {
+    destination_category: "ckb_fundamentals",
+    prefixes: ["ckb-fundamentals"],
+  },
+  {
+    destination_category: "resources",
+    prefixes: ["tech-explanation/glossary"],
+  },
+  {
+    destination_category: "core_structures",
+    prefixes: ["tech-explanation"],
+  },
+  {
+    destination_category: "assets_token_standards",
+    prefixes: ["assets-token-standards"],
+  },
+  {
+    destination_category: "ecosystem",
+    prefixes: ["ecosystem/projects", "ecosystem/organizations"],
+  },
+  {
+    destination_category: "contribution",
+    prefixes: ["ecosystem/contribute"],
+  },
+  {
+    destination_category: "run_a_node",
+    prefixes: ["node"],
+  },
+  {
+    destination_category: "history_hard_forks",
+    prefixes: ["history-and-hard-forks"],
+  },
+  {
+    destination_category: "mining",
+    prefixes: ["mining"],
+  },
+];
+
+function getDocDestinationCategory(pathname: string): string | undefined {
+  const docPath = pathname.replace(/^\/docs\/?/, "").replace(/\/$/, "");
+
+  return DOC_DESTINATION_CATEGORIES.find(({ prefixes }) =>
+    prefixes.some(
+      (prefix) => docPath === prefix || docPath.startsWith(`${prefix}/`)
+    )
+  )?.destination_category;
+}
+
+export function getDeveloperDestination(url: URL): {
+  destination_category: string;
+} {
+  const hostname = url.hostname.replace(/^www\./, "");
+  const pathname = url.pathname.toLowerCase();
+  const isInternalDocsLink = hostname === window.location.hostname;
+
+  if (
+    getLlmsFileName(url.href) ||
+    hostname === "ckb-ai.ckbdev.com" ||
+    hostname === "mcp.ckbdev.com"
+  ) {
+    return {
+      destination_category: "ai_agents",
+    };
+  }
+
+  if (isInternalDocsLink && pathname.startsWith("/docs")) {
+    return {
+      destination_category: getDocDestinationCategory(pathname) || "other",
+    };
+  }
+
+  if (hostname === "github.com") {
+    return {
+      destination_category: pathname.includes("/discussions")
+        ? "community"
+        : "source_repository",
+    };
+  }
+
+  if (
+    hostname === "discord.gg" ||
+    hostname === "t.me" ||
+    hostname === "talk.nervos.org"
+  ) {
+    return {
+      destination_category: "community",
+    };
+  }
+
+  return {
+    destination_category: "other",
+  };
+}

--- a/website/src/components/CopyLink/index.tsx
+++ b/website/src/components/CopyLink/index.tsx
@@ -1,4 +1,8 @@
 import React, { useState } from "react";
+import {
+  getLlmsFileName,
+  sendAnalyticsEvent,
+} from "@site/src/components/AnalyticsTracking/utils";
 import styles from "./styles.module.css";
 
 interface CopyLinkProps {
@@ -13,6 +17,17 @@ const CopyLink: React.FC<CopyLinkProps> = ({ url, children }) => {
   const copyToClipboard = (e: React.MouseEvent<HTMLSpanElement>) => {
     e.preventDefault(); // Prevent the default download behavior
     navigator.clipboard.writeText(url).then(() => {
+      const copiedUrl = new URL(url, window.location.href);
+      const llmsFile = getLlmsFileName(copiedUrl.href);
+
+      sendAnalyticsEvent("copy_link", {});
+
+      if (llmsFile) {
+        sendAnalyticsEvent("llms_file_action", {
+          llms_action: "copy_url",
+        });
+      }
+
       setIsCopied(true);
       setLinkText("Link copied to clipboard!");
       setTimeout(() => {

--- a/website/src/components/LinkClickTracker/index.tsx
+++ b/website/src/components/LinkClickTracker/index.tsx
@@ -1,56 +1,18 @@
 import { useEffect } from "react";
-import { useLocation } from "@docusaurus/router";
 import {
-  getSafePagePath,
-  getSafeUrl,
+  getDeveloperDestination,
+  getLlmsFileName,
+  sendAnalyticsEvent,
 } from "@site/src/components/AnalyticsTracking/utils";
 
 const TRACKED_LINK_PROTOCOLS = new Set(["http:", "https:"]);
 
-function getElementLabel(element: HTMLAnchorElement): string {
-  const imageAlt = element.querySelector("img")?.getAttribute("alt");
-  const label =
-    element.innerText ||
-    element.getAttribute("aria-label") ||
-    element.getAttribute("title") ||
-    imageAlt ||
-    "";
-
-  return label.trim().replace(/\s+/g, " ").slice(0, 100);
-}
-
-function getClickArea(element: Element): string {
-  if (element.closest("main article")) {
-    return "article";
-  }
-
-  if (
-    element.closest(
-      "aside, nav[aria-label='Docs sidebar'], .theme-doc-sidebar-container"
-    )
-  ) {
-    return "sidebar";
-  }
-
-  if (element.closest("header, .navbar")) {
-    return "navbar";
-  }
-
-  if (element.closest("footer")) {
-    return "footer";
-  }
-
-  return "page";
-}
-
 export default function LinkClickTracker(): null {
-  const location = useLocation();
-
   useEffect(() => {
     const handleLinkClick = (event: MouseEvent) => {
       const target = event.target;
 
-      if (!(target instanceof Element) || !window.gtag) {
+      if (!(target instanceof Element)) {
         return;
       }
 
@@ -66,15 +28,17 @@ export default function LinkClickTracker(): null {
         return;
       }
 
-      window.gtag("event", "link_click", {
-        click_area: getClickArea(link),
-        link_text: getElementLabel(link),
-        link_url: getSafeUrl(linkUrl.href),
-        link_domain: linkUrl.hostname,
-        outbound: linkUrl.hostname !== window.location.hostname,
-        page_path: getSafePagePath(location),
-        page_title: document.title,
+      const llmsFile = getLlmsFileName(linkUrl.href);
+
+      sendAnalyticsEvent("link_click", {
+        ...getDeveloperDestination(linkUrl),
       });
+
+      if (llmsFile && link.dataset.llmsActionTracked !== "true") {
+        sendAnalyticsEvent("llms_file_action", {
+          llms_action: link.hasAttribute("download") ? "download" : "open",
+        });
+      }
     };
 
     document.addEventListener("click", handleLinkClick);
@@ -82,7 +46,7 @@ export default function LinkClickTracker(): null {
     return () => {
       document.removeEventListener("click", handleLinkClick);
     };
-  }, [location.pathname, location.hash]);
+  }, []);
 
   return null;
 }

--- a/website/src/components/LlmFileActions/index.tsx
+++ b/website/src/components/LlmFileActions/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { sendAnalyticsEvent } from "@site/src/components/AnalyticsTracking/utils";
 import styles from "./styles.module.css";
 
 type Props = {
@@ -13,6 +14,9 @@ export default function LlmFileActions({ path, filename }: Props): JSX.Element {
     const response = await fetch(path);
     const text = await response.text();
     await navigator.clipboard.writeText(text);
+    sendAnalyticsEvent("llms_file_action", {
+      llms_action: "copy_file_content",
+    });
     setCopied(true);
     window.setTimeout(() => setCopied(false), 2000);
   }
@@ -32,6 +36,12 @@ export default function LlmFileActions({ path, filename }: Props): JSX.Element {
         className={styles.iconButton}
         href={path}
         download={filename}
+        data-llms-action-tracked="true"
+        onClick={() => {
+          sendAnalyticsEvent("llms_file_action", {
+            llms_action: "download",
+          });
+        }}
         aria-label={`Download ${filename}`}
         title="Download file"
       >

--- a/website/src/components/ScrollDepthTracker/index.tsx
+++ b/website/src/components/ScrollDepthTracker/index.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "@docusaurus/router";
-import { getSafePagePath } from "@site/src/components/AnalyticsTracking/utils";
+import {
+  getSafePagePath,
+  sendAnalyticsEvent,
+} from "@site/src/components/AnalyticsTracking/utils";
 
 const SCROLL_MILESTONES = [25, 50, 75, 90, 100];
 
@@ -39,10 +42,6 @@ export default function ScrollDepthTracker(): null {
     const sendScrollDepthEvents = () => {
       animationFrame.current = null;
 
-      if (!window.gtag) {
-        return;
-      }
-
       const scrollDepth = getScrollDepth();
       const pagePath = getSafePagePath(location);
 
@@ -52,7 +51,7 @@ export default function ScrollDepthTracker(): null {
           !trackedMilestones.current.has(milestone)
         ) {
           trackedMilestones.current.add(milestone);
-          window.gtag("event", "scroll_depth", {
+          sendAnalyticsEvent("scroll_depth", {
             percent_scrolled: milestone,
             page_path: pagePath,
             page_title: document.title,

--- a/website/src/components/SearchTermTracker/index.tsx
+++ b/website/src/components/SearchTermTracker/index.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "@docusaurus/router";
 import {
+  getDeveloperDestination,
   getSafePagePath,
-  getSafeUrl,
+  sendAnalyticsEvent,
 } from "@site/src/components/AnalyticsTracking/utils";
 
 const SEARCH_INPUT_SELECTOR = ".aa-Input";
+const SEARCH_RESULT_LINK_SELECTOR = ".aa-ItemLink";
+const SELECTED_SEARCH_RESULT_SELECTOR =
+  ".aa-Item[aria-selected='true'] .aa-ItemLink, .aa-Item[aria-current='true'] .aa-ItemLink";
 const SEARCH_EVENT_DELAY = 1000;
 const MAX_SEARCH_TERM_LENGTH = 100;
 const SENSITIVE_SEARCH_PATTERNS = [
@@ -21,6 +25,12 @@ function getSafeSearchTerm(value: string): string {
   ).slice(0, MAX_SEARCH_TERM_LENGTH);
 }
 
+function getSearchResultLinks(): HTMLAnchorElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLAnchorElement>(SEARCH_RESULT_LINK_SELECTOR)
+  );
+}
+
 export default function SearchTermTracker(): null {
   const location = useLocation();
   const trackedSearchTerms = useRef<Set<string>>(new Set());
@@ -28,7 +38,7 @@ export default function SearchTermTracker(): null {
 
   useEffect(() => {
     const sendSearchTermEvent = (searchTerm: string) => {
-      if (!window.gtag || !searchTerm) {
+      if (!searchTerm) {
         return;
       }
 
@@ -40,11 +50,31 @@ export default function SearchTermTracker(): null {
       }
 
       trackedSearchTerms.current.add(trackingKey);
-      window.gtag("event", "view_search_results", {
+      const resultCount = getSearchResultLinks().length;
+      const searchParams = {
         search_term: searchTerm,
-        page_path: pagePath,
-        page_title: document.title,
-      });
+        result_count: resultCount,
+        no_results: resultCount === 0,
+      };
+
+      sendAnalyticsEvent("view_search_results", searchParams);
+
+      if (resultCount === 0) {
+        sendAnalyticsEvent("search_no_results", {
+          search_term: searchTerm,
+          no_results: true,
+        });
+      }
+    };
+
+    const scheduleSearchTermEvent = (searchTerm: string) => {
+      if (searchEventTimer.current !== null) {
+        window.clearTimeout(searchEventTimer.current);
+      }
+
+      searchEventTimer.current = window.setTimeout(() => {
+        sendSearchTermEvent(searchTerm);
+      }, SEARCH_EVENT_DELAY);
     };
 
     const handleSearchInput = (event: Event) => {
@@ -57,15 +87,29 @@ export default function SearchTermTracker(): null {
         return;
       }
 
-      const searchTerm = getSafeSearchTerm(target.value);
+      scheduleSearchTermEvent(getSafeSearchTerm(target.value));
+    };
 
-      if (searchEventTimer.current !== null) {
-        window.clearTimeout(searchEventTimer.current);
+    const sendSearchSelectionEvent = (selectedLink: HTMLAnchorElement) => {
+      const searchInput = document.querySelector<HTMLInputElement>(
+        SEARCH_INPUT_SELECTOR
+      );
+      const searchTerm = getSafeSearchTerm(searchInput?.value || "");
+
+      if (!searchTerm) {
+        return;
       }
 
-      searchEventTimer.current = window.setTimeout(() => {
-        sendSearchTermEvent(searchTerm);
-      }, SEARCH_EVENT_DELAY);
+      const resultLinks = getSearchResultLinks();
+      const resultRank = resultLinks.indexOf(selectedLink) + 1;
+      const selectedUrl = new URL(selectedLink.href, window.location.href);
+
+      sendAnalyticsEvent("select_search_result", {
+        search_term: searchTerm,
+        result_count: resultLinks.length,
+        result_rank: resultRank || undefined,
+        ...getDeveloperDestination(selectedUrl),
+      });
     };
 
     const handleSearchSelection = (event: MouseEvent | KeyboardEvent) => {
@@ -84,25 +128,16 @@ export default function SearchTermTracker(): null {
 
       const selectedLink =
         event instanceof MouseEvent
-          ? target.closest<HTMLAnchorElement>(".aa-ItemLink")
+          ? target.closest<HTMLAnchorElement>(SEARCH_RESULT_LINK_SELECTOR)
           : document.querySelector<HTMLAnchorElement>(
-              ".aa-Item[aria-selected='true'] .aa-ItemLink, .aa-Item[aria-current='true'] .aa-ItemLink, .aa-ItemLink"
+              SELECTED_SEARCH_RESULT_SELECTOR
             );
-      const searchInput = document.querySelector<HTMLInputElement>(
-        SEARCH_INPUT_SELECTOR
-      );
-      const searchTerm = getSafeSearchTerm(searchInput?.value || "");
 
-      if (!selectedLink || !window.gtag || !searchTerm) {
+      if (!selectedLink) {
         return;
       }
 
-      window.gtag("event", "select_search_result", {
-        search_term: searchTerm,
-        page_path: getSafePagePath(location),
-        page_title: document.title,
-        link_url: getSafeUrl(selectedLink.href),
-      });
+      sendSearchSelectionEvent(selectedLink);
     };
 
     document.addEventListener("input", handleSearchInput);

--- a/website/src/global.d.ts
+++ b/website/src/global.d.ts
@@ -1,3 +1,3 @@
 declare interface Window {
-  gtag: (...args: any[]) => void;
+  gtag?: (...args: any[]) => void;
 }

--- a/website/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/website/src/theme/CodeBlock/CopyButton/index.tsx
@@ -5,15 +5,55 @@ import { translate } from "@docusaurus/Translate";
 import type { Props } from "@theme/CodeBlock/CopyButton";
 import IconCopy from "@theme/Icon/Copy";
 import IconSuccess from "@theme/Icon/Success";
+import {
+  getLlmsFileNameFromText,
+  sendAnalyticsEvent,
+} from "@site/src/components/AnalyticsTracking/utils";
 
 import styles from "./styles.module.css";
+
+function getCodeBlockMetadata(button: HTMLButtonElement | null): {
+  code_block_index?: number;
+  code_block_label?: string;
+} {
+  const codeBlock = button?.closest<HTMLElement>(".theme-code-block");
+  const title = codeBlock
+    ?.querySelector<HTMLElement>("[class*='codeBlockTitle']")
+    ?.textContent?.trim();
+  const codeBlocks = Array.from(
+    document.querySelectorAll<HTMLElement>(".theme-code-block")
+  );
+  const codeBlockIndex = codeBlock ? codeBlocks.indexOf(codeBlock) + 1 : 0;
+  const fallbackLabel =
+    codeBlockIndex > 0 ? `snippet_${codeBlockIndex}` : "snippet";
+
+  return {
+    code_block_index: codeBlockIndex || undefined,
+    code_block_label: title || fallbackLabel,
+  };
+}
 
 export default function CopyButton({ code, className }: Props): JSX.Element {
   const [isCopied, setIsCopied] = useState(false);
   const copyTimeout = useRef<number | undefined>(undefined);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const handleCopyCode = useCallback(() => {
     copy(code);
     setIsCopied(true);
+    const codeBlockMetadata = getCodeBlockMetadata(buttonRef.current);
+
+    sendAnalyticsEvent("copy_code", {
+      ...codeBlockMetadata,
+    });
+
+    const llmsFile = getLlmsFileNameFromText(code);
+
+    if (llmsFile) {
+      sendAnalyticsEvent("llms_file_action", {
+        llms_action: "copy_reference",
+      });
+    }
+
     copyTimeout.current = window.setTimeout(() => {
       setIsCopied(false);
     }, 1000);
@@ -23,6 +63,7 @@ export default function CopyButton({ code, className }: Props): JSX.Element {
 
   return (
     <button
+      ref={buttonRef}
       type="button"
       aria-label={
         isCopied

--- a/website/src/theme/NotFound/Content/index.tsx
+++ b/website/src/theme/NotFound/Content/index.tsx
@@ -12,16 +12,11 @@ import ThemedImage from "@theme/ThemedImage";
 import styles from "./styles.module.css";
 import Button from "@site/src/components/Button";
 import Link from "@docusaurus/Link";
+import { sendAnalyticsEvent } from "@site/src/components/AnalyticsTracking/utils";
 
 export default function NotFoundContent({ className }: Props): JSX.Element {
   const sendEvent = () => {
-    if (window.gtag) {
-      window.gtag("event", "page_view", {
-        page_title: "404 Page Not Found",
-        page_location: window.location.href, // URL of the current page
-        referrer: document.referrer, // URL of the previous page
-      });
-    }
+    sendAnalyticsEvent("page_not_found", {});
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description 
Adds GA4 tracking improvements for CKB Docs so we can better understand search quality, code-copy behavior, LLMS usage, destination categories, scroll depth, and 404s.
## Changes
- Added shared analytics helpers with localhost and missing-gtag guards.
- Disabled Docusaurus built-in gtag outside production or explicit opt-in.
- Added search tracking for result count, no-result searches, and selected result rank.
- Added copy_code tracking with page-relative code block label and index.
- Added tracking for CopyLink interactions and LLMS file copy/download/open actions.
- Added dedicated page_not_found event for 404 pages.
- Updated link_click tracking to use sidebar-aligned destination_category values.
- Routed scroll_depth through the shared analytics helper.