### PR TITLE
fix: broken links and anchors

### DIFF
--- a/website/docs/ckb-fundamentals/ckb-vm.md
+++ b/website/docs/ckb-fundamentals/ckb-vm.md
@@ -19,7 +19,7 @@ Nervos CKB offers native SDKs in several mainstream programming languages, such 
 
 ## CKB-VM Version
 
-The CKB network has introduced various CKB-VM versions over time to enhance security, performance, resolve bugs, and support new RISC-V extensions. To check out all versions of the CKB-VM from previous hard fork events, please visit [VM Version History](/docs/history-and-hard-forks/history-vm-version)
+The CKB network has introduced various CKB-VM versions over time to enhance security, performance, resolve bugs, and support new RISC-V extensions. To check out all versions of the CKB-VM from previous hard fork events, please visit [VM Version History](/docs/script/vm-version)
 
 ---
 

--- a/website/docs/ckb-fundamentals/nervos-blockchain.md
+++ b/website/docs/ckb-fundamentals/nervos-blockchain.md
@@ -28,7 +28,7 @@ To store 100 bytes of data in Nervos, it is mandatory to have 100 CKBytes. If yo
 
 CKBytes can also be deposited in the Nervos DAO，where they gain rewards in a staking-like process.
 
-Further information about CKByte will be presented in the [Cell Model](cell-model.md) and [Economics](economics.md) sections.
+Further information about CKByte will be presented in the [Cell Model](cell-model.md) and [Economics](/docs/assets-token-standards/economics) sections.
 
 ## Programming on Nervos
 

--- a/website/docs/node/install-ckb.mdx
+++ b/website/docs/node/install-ckb.mdx
@@ -10,9 +10,9 @@ import TabItem from "@theme/TabItem";
 
 There are three ways to install and run the CKB binary, depending on your platform and preference:
 
-- [Download from release](#download-from-release) – the fastest way. Grab a prebuilt binary package from the official GitHub Releases
+- [Download from release](#method-1-download-from-release) – the fastest way. Grab a prebuilt binary package from the official GitHub Releases
   page and unzip it.
-- [Build from source](#build-from-source) – recommended if you want to compile with the latest changes or verify the build process yourself.
+- [Build from source](#method-2-build-from-source) – recommended if you want to compile with the latest changes or verify the build process yourself.
 - [Use Docker](/docs/node/run-node-docker) – if your platform isn’t directly supported, or if you prefer containerized environments, you can run CKB inside Docker.
 
 ## Method 1: Download from Release

--- a/website/docs/node/node-configuration.mdx
+++ b/website/docs/node/node-configuration.mdx
@@ -35,9 +35,9 @@ ckb.toml
 
 This article covers the following configuration topics:
 
-- [Node Discoverability](#improve-node-discoverability)
+- [Node Discoverability](#node-discoverability)
 - [Light client support and WSS access](#light-client-support--wss-access)
-- [Proxy and onion support](#proxy-and-onion-support)
+- [Proxy and onion support](#proxy-and-toronion)
 - [Fee estimator](#fee-estimator)
 - [Run multiple nodes](#run-multiple-nodes)
 

--- a/website/docs/script/debug-script.mdx
+++ b/website/docs/script/debug-script.mdx
@@ -438,7 +438,7 @@ where:
 - `__ckb_std_main`: the entry function. When executed, it dynamically loads the lib and runs this function. The transaction information of the Script is passed through the two above-mentioned environment variables.
 - `__set_script_info`: responsible for passing the global state necessary for `exec` and `spawn`.
 
-:::Attention
+:::caution Attention
 
 - The separate crate `$crate::env::Arg` is used to prevent project complexity, as combining these two functions would complicate maintenance.
 - For developers wishing to use this feature, we recommend to use `ckb-testtool` for development and testing to simplify work.

--- a/website/docs/script/js/01-02-js-vm-cmd-line.mdx
+++ b/website/docs/script/js/01-02-js-vm-cmd-line.mdx
@@ -12,7 +12,7 @@ ckb-js-vm supports the following options to control its execution behavior:
 - `-e <code>`: Execute JavaScript code directly from the command line string
 - `-r <filename>`: Read and execute JavaScript code from the specified file
 - `-t <target>`: Specify the target resource cell's code_hash and hash_type in hexadecimal format
-- `-f`: Enable [file system](./js-vm#simple-file-system-and-modules) mode, which provides support for JavaScript modules and imports
+- `-f`: Enable [file system](./js-vm-file-system) mode, which provides support for JavaScript modules and imports
 
 Note, the `-c` and `-r` options can only work with `ckb-debugger`. The `-c` option is particularly useful for preparing
 optimized bytecode as described in the previous section. When no options are specified, ckb-js-vm runs in its default

--- a/website/docs/script/js/01-04-file-system.mdx
+++ b/website/docs/script/js/01-04-file-system.mdx
@@ -59,7 +59,7 @@ While it's often more resource-efficient to write all JavaScript code in a singl
 support in ckb-js-vm through either:
 
 - Executing or spawning ckb-js-vm with the "-f" parameter
-- Using ckb-js-vm flags with file system enabled (see the [Working with ckb-js-vm](./js-vm#ckb-js-vm-command-line-options) chapter for details)
+- Using ckb-js-vm flags with file system enabled (see the [Command Line Options](./js-vm-cmd-line-options) chapter for details)
 
 ### Unpacking a Simple File System
 

--- a/website/docs/script/rust/rust-debug.mdx
+++ b/website/docs/script/rust/rust-debug.mdx
@@ -438,7 +438,7 @@ where:
 - `__ckb_std_main`: the entry function. When executed, it dynamically loads the lib and runs this function. The transaction information of the Script is passed through the two above-mentioned environment variables.
 - `__set_script_info`: responsible for passing the global state necessary for `exec` and `spawn`.
 
-:::Attention
+:::caution Attention
 
 - The separate crate `$crate::env::Arg` is used to prevent project complexity, as combining these two functions would complicate maintenance.
 - For developers wishing to use this feature, we recommend to use `ckb-testtool` for development and testing to simplify work.

--- a/website/docs/script/spawn-direct-cross-script-calling.mdx
+++ b/website/docs/script/spawn-direct-cross-script-calling.mdx
@@ -10,11 +10,11 @@ import ExampleLink from "@site/src/components/ExampleLink";
 
 The Meepo hard fork in 2024 has introduced a range of enhancements into CKB Script development, with one major innovation being Spawn.
 
-In [CKB Script](/docs/script/intro-to-script), Spawn refers to a concept and a set of syscalls for creating new processes. Unlike the [exec syscall](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0034-vm-syscalls-2/0034-vm-syscalls-2.md#exec) introduced during [CKB’s first hard fork in 2021](/docs/history-and-hard-forks/ckb-hard-fork-history#1st-hard-fork--ckb-edition-mirana-2021), Spawn enables **direct cross-script calls**, simplifying development process while offering greater control and optimization.
+In [CKB Script](/docs/script/intro-to-script), Spawn refers to a concept and a set of syscalls for creating new processes. Unlike the [exec syscall](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0034-vm-syscalls-2/0034-vm-syscalls-2.md#exec) introduced during [CKB’s first hard fork in 2021](/docs/history-and-hard-forks/ckb-hard-fork-history#mirana-hardfork), Spawn enables **direct cross-script calls**, simplifying development process while offering greater control and optimization.
 
 ## Why Spawn
 
-The exec syscall, introduced into <Tooltip>CKB-VM</Tooltip> during [CKB’s first hard fork](/docs/history-and-hard-forks/ckb-hard-fork-history#1st-hard-fork--ckb-edition-mirana-2021), was designed to enable the loading and executing of a new Script within the current execution space. While powerful, exec can be inefficient, especially when preserving the current execution space is necessary. With exec, all state information of the current Script is discarded. When Script A calls Script B using exec, Script A's context is lost (This means that even if Script A has remaining code after executing `exec`, that code will not be executed.), as illustrated below:
+The exec syscall, introduced into <Tooltip>CKB-VM</Tooltip> during [CKB’s first hard fork](/docs/history-and-hard-forks/ckb-hard-fork-history#mirana-hardfork), was designed to enable the loading and executing of a new Script within the current execution space. While powerful, exec can be inefficient, especially when preserving the current execution space is necessary. With exec, all state information of the current Script is discarded. When Script A calls Script B using exec, Script A's context is lost (This means that even if Script A has remaining code after executing `exec`, that code will not be executed.), as illustrated below:
 
 ```
       +----------+   Exec   +----------+

--- a/website/docs/tech-explanation/outputs.md
+++ b/website/docs/tech-explanation/outputs.md
@@ -5,4 +5,4 @@ title: outputs
 
 # outputs
 
-The transaction destroys the Cells listed in `inputs` and creates new Cells listed in `outputs`. These output Cells follow the same structure as the standard [Cell structure](<(/docs/tech-explanation/cell#cell-structure)>) and can later be used as inputs in future transactions.
+The transaction destroys the Cells listed in `inputs` and creates new Cells listed in `outputs`. These output Cells follow the same structure as the standard [Cell structure](/docs/tech-explanation/cell#cell-structure) and can later be used as inputs in future transactions.


### PR DESCRIPTION
## Summary
Fixes docs build warnings caused by broken links, broken anchors, and invalid Markdown admonition syntax.
## Changes
- Fixed broken Economics link in the Nervos Blockchain page.
- Updated outdated CKB-VM version history link.
- Fixed malformed Cell structure link.
- Corrected broken in-page anchors in node installation and node configuration docs.
- Updated JS VM cross-links to point to existing pages.
- Fixed hard fork anchor links to use the existing #mirana-hardfork anchor.
- Replaced invalid :::Attention directives with valid Docusaurus admonitions.