### PR TITLE
chore: remove logrocket tracking

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -44,7 +44,6 @@
     "clsx": "^1.1.1",
     "connect": "^3.7.0",
     "hast-util-is-element": "1.1.0",
-    "logrocket": "^8.1.0",
     "prism-react-renderer": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import LogRocket from "logrocket";
 import Layout from "@theme/Layout";
 import clsx from "clsx";
 import { useColorMode } from "@docusaurus/theme-common";
@@ -22,10 +21,6 @@ import {
 } from "../components/Home";
 
 export default function Home() {
-  useEffect(() => {
-    LogRocket.init("ghkibu/nervos-doc");
-  }, []);
-
   return (
     <Layout
       wrapperClassName={clsx(styles.homeLayout, styles.relative)}

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6983,11 +6983,6 @@ log-update@^6.0.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-logrocket@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/logrocket/-/logrocket-8.1.0.tgz#2b804985b5370b359831ee03c92423e08ac48044"
-  integrity sha512-0PRv9lnS90KBrL3mfiQzcKEPvNT3N55pRN0PRe/q3DqWFQbIW1p72MmMp9a3Qi9la6o+TXri7r68ZE0AM7vsDA==
-
 longest-streak@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"


### PR DESCRIPTION
## Summary
Remove LogRocket tracking from the docs homepage and dependency metadata.

## Changes
- Remove the LogRocket import and initialization from the landing page
- Remove the LogRocket dependency from package.json
- Remove the LogRocket lockfile entry