### PR TITLE
fix: add redirects for known 404 doc paths

### DIFF
--- a/examples/dApp/simple-lock/frontend/app/page.tsx
+++ b/examples/dApp/simple-lock/frontend/app/page.tsx
@@ -91,7 +91,7 @@ function HashLock() {
     amountInCKB.length > 0 && +amountInCKB < 61 ? (
       <span>
         amount must larger than 61 CKB, see{" "}
-        <a href="https://docs.nervos.org/docs/wallets/#requirements-for-ckb-transfers">
+        <a href="https://docs.nervos.org/docs/integrate-wallets/intro-to-wallets/#requirements-for-ckb-transfers">
           why
         </a>
       </span>

--- a/examples/dApp/simple-transfer/index.tsx
+++ b/examples/dApp/simple-transfer/index.tsx
@@ -73,7 +73,7 @@ export function App() {
     amountInCKB.length > 0 && +amountInCKB < 61 ? (
       <span>
         amount must larger than 61 CKB, see{' '}
-        <a href="https://docs.nervos.org/docs/wallets/#requirements-for-ckb-transfers">why</a>
+        <a href="https://docs.nervos.org/docs/integrate-wallets/intro-to-wallets/#requirements-for-ckb-transfers">why</a>
       </span>
     ) : null;
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -216,6 +216,45 @@ const config = {
             from: "/docs/sdk-and-devtool/lumos",
             to: "/docs/sdk-and-devtool/ccc",
           },
+          {
+            from: [
+              "/docs/basics/guides/crypto wallets/imtoken",
+              "/docs/basics/guides/imtoken",
+            ],
+            to: "https://docs-old.nervos.org/docs/basics/guides/crypto wallets/imtoken",
+          },
+          {
+            from: "/docs/tech-explanation/ckb-vs-btc",
+            to: "/docs/ckb-fundamentals/ckb-vs-btc",
+          },
+          {
+            from: "/docs/tech-explanation/ckb-address",
+            to: "/docs/ckb-fundamentals/ckb-address",
+          },
+          {
+            from: "/docs/script-course/intro-to-script-1",
+            to: "/docs/script/intro-to-script",
+          },
+          {
+            from: "/docs/script-course/intro-to-script-2",
+            to: "/docs/script/program-language-for-script",
+          },
+          {
+            from: "/docs/script/ckb-script-ipc",
+            to: "/docs/script/ckb-ipc",
+          },
+          {
+            from: "/docs/script/rust/rust-example-spawn-script",
+            to: "/docs/script/rust/rust-api-spawn",
+          },
+          {
+            from: ["/docs/wallets", "/getting-started/wallet"],
+            to: "/docs/integrate-wallets/intro-to-wallets",
+          },
+          {
+            from: "/docs/getting-started/blockchain-networks",
+            to: "/docs/getting-started/ckb-networks",
+          },
         ],
         createRedirects(existingPath) {
           if (


### PR DESCRIPTION
## Summary

Adds client-side redirects for stale doc URLs flagged by the docs.nervos.org 404-tracking bot. Each redirect points to the current canonical location (some pages moved sections, others changed their `id`/slug, and a couple only exist on the old docs site).

## Redirects added

| Old (404) path | Redirect target |
| --- | --- |
| `/docs/tech-explanation/ckb-vs-btc` | `/docs/ckb-fundamentals/ckb-vs-btc` |
| `/docs/tech-explanation/ckb-address` | `/docs/ckb-fundamentals/ckb-address` |
| `/docs/script-course/intro-to-script-1` | `/docs/script/intro-to-script` |
| `/docs/script-course/intro-to-script-2` | `/docs/script/program-language-for-script` |
| `/docs/script/ckb-script-ipc` | `/docs/script/ckb-ipc` (page `id` is `ckb-ipc`) |
| `/docs/script/rust/rust-example-spawn-script` | `/docs/script/rust/rust-api-spawn` |
| `/docs/wallets`, `/getting-started/wallet` | `/docs/integrate-wallets/intro-to-wallets` |
| `/docs/getting-started/blockchain-networks` | `/docs/getting-started/ckb-networks` (page `id` is `ckb-networks`) |
| `/docs/basics/guides/crypto wallets/imtoken`, `/docs/basics/guides/imtoken` | `https://docs-old.nervos.org/.../imtoken` |

### Notes
- `blockchain-networks` and `ckb-script-ipc` still 404 because their files set a custom `id` frontmatter (`ckb-networks` / `ckb-ipc`), which becomes the live URL.
- `imToken` only ever existed on the old docs site, so it redirects there — consistent with the existing `neuron` redirect.

## Testing

`yarn build` completes successfully and all redirect HTML files are generated under `build/` with the correct `<meta http-equiv="refresh">` targets.
