### PR TITLE
feat: track 404 referrers

### DIFF
--- a/website/src/components/AnalyticsTracking/utils.ts
+++ b/website/src/components/AnalyticsTracking/utils.ts
@@ -15,6 +15,9 @@ type AnalyticsEventParams = Record<
   string | number | boolean | null | undefined
 >;
 
+const CURRENT_PAGE_PATH_KEY = "ckb_docs_current_page_path";
+const PREVIOUS_PAGE_PATH_KEY = "ckb_docs_previous_page_path";
+
 function isLocalAnalyticsHost(): boolean {
   return (
     window.location.hostname === "localhost" ||
@@ -25,6 +28,84 @@ function isLocalAnalyticsHost(): boolean {
 
 export function getCurrentPagePath(): string {
   return `${window.location.pathname}${window.location.hash || ""}`;
+}
+
+function getSessionStorageValue(key: string): string | undefined {
+  try {
+    return window.sessionStorage.getItem(key) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function setSessionStorageValue(key: string, value: string): void {
+  try {
+    window.sessionStorage.setItem(key, value);
+  } catch {
+    // Ignore storage failures from private browsing or blocked storage.
+  }
+}
+
+function removeSessionStorageValue(key: string): void {
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Ignore storage failures from private browsing or blocked storage.
+  }
+}
+
+export function rememberCurrentPagePath(
+  pagePath: string,
+  { updatePreviousPagePath = true }: { updatePreviousPagePath?: boolean } = {}
+): void {
+  const currentPagePath = getSessionStorageValue(CURRENT_PAGE_PATH_KEY);
+
+  if (
+    updatePreviousPagePath &&
+    currentPagePath &&
+    currentPagePath !== pagePath
+  ) {
+    setSessionStorageValue(PREVIOUS_PAGE_PATH_KEY, currentPagePath);
+  } else if (!updatePreviousPagePath) {
+    removeSessionStorageValue(PREVIOUS_PAGE_PATH_KEY);
+  }
+
+  setSessionStorageValue(CURRENT_PAGE_PATH_KEY, pagePath);
+}
+
+export function getPageNotFoundSourceParams(): AnalyticsEventParams {
+  const pagePath = getCurrentPagePath();
+  const previousPagePath = getSessionStorageValue(PREVIOUS_PAGE_PATH_KEY);
+  const referrer = document.referrer;
+
+  if (!referrer) {
+    return {
+      page_not_found_path: pagePath,
+      previous_page_path: previousPagePath,
+      referrer_type: previousPagePath ? "internal" : "direct",
+    };
+  }
+
+  let referrerUrl: URL;
+
+  try {
+    referrerUrl = new URL(referrer);
+  } catch {
+    return {
+      page_not_found_path: pagePath,
+      previous_page_path: previousPagePath,
+      referrer_type: previousPagePath ? "internal" : "unknown",
+    };
+  }
+
+  const isInternalReferrer = referrerUrl.origin === window.location.origin;
+
+  return {
+    page_not_found_path: pagePath,
+    previous_page_path: previousPagePath,
+    referrer_type: isInternalReferrer ? "internal" : "external",
+    referrer_url: referrerUrl.href,
+  };
 }
 
 export function sendAnalyticsEvent(

--- a/website/src/components/PagePathTracker/index.tsx
+++ b/website/src/components/PagePathTracker/index.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "@docusaurus/router";
+import {
+  getSafePagePath,
+  rememberCurrentPagePath,
+} from "@site/src/components/AnalyticsTracking/utils";
+
+export default function PagePathTracker(): null {
+  const location = useLocation();
+  const hasTrackedInitialPagePath = useRef(false);
+
+  useEffect(() => {
+    rememberCurrentPagePath(getSafePagePath(location), {
+      updatePreviousPagePath: hasTrackedInitialPagePath.current,
+    });
+    hasTrackedInitialPagePath.current = true;
+  }, [location.pathname, location.hash]);
+
+  return null;
+}

--- a/website/src/theme/NotFound/Content/index.tsx
+++ b/website/src/theme/NotFound/Content/index.tsx
@@ -12,11 +12,14 @@ import ThemedImage from "@theme/ThemedImage";
 import styles from "./styles.module.css";
 import Button from "@site/src/components/Button";
 import Link from "@docusaurus/Link";
-import { sendAnalyticsEvent } from "@site/src/components/AnalyticsTracking/utils";
+import {
+  getPageNotFoundSourceParams,
+  sendAnalyticsEvent,
+} from "@site/src/components/AnalyticsTracking/utils";
 
 export default function NotFoundContent({ className }: Props): JSX.Element {
   const sendEvent = () => {
-    sendAnalyticsEvent("page_not_found", {});
+    sendAnalyticsEvent("page_not_found", getPageNotFoundSourceParams());
   };
 
   useEffect(() => {

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,11 +1,13 @@
 import type { Props } from "@theme/Root";
 import LinkClickTracker from "@site/src/components/LinkClickTracker";
+import PagePathTracker from "@site/src/components/PagePathTracker";
 import SearchTermTracker from "@site/src/components/SearchTermTracker";
 import ScrollDepthTracker from "@site/src/components/ScrollDepthTracker";
 
 export default function Root({ children }: Props): JSX.Element {
   return (
     <>
+      <PagePathTracker />
       <LinkClickTracker />
       <SearchTermTracker />
       <ScrollDepthTracker />


### PR DESCRIPTION
## Summary
Adds GA4 context to 404 tracking so reports can show how users reached missing pages.

## Changes
- Adds a lightweight page path tracker for Docusaurus SPA navigation.
- Sends page_not_found_path, previous_page_path, referrer_type, and referrer_url with page_not_found events.
- Clears stale previous-page data on initial page load to avoid misclassifying direct or external 404 visits.

## Verification
- Ran npm run build.