### PR TITLE
docs: replace visible doc tags with keywords

### DIFF
--- a/website/docs/ckb-fundamentals/cell-model.md
+++ b/website/docs/ckb-fundamentals/cell-model.md
@@ -2,7 +2,7 @@
 id: cell-model
 title: Cell Model
 description: "Understand CKB's generalized UTXO Cell Model, including Live Cells, Dead Cells, capacity, ownership, state rent, and scalability."
-tags:
+keywords:
   - concept
   - cell-model
   - utxo

--- a/website/docs/ckb-fundamentals/nervos-blockchain.md
+++ b/website/docs/ckb-fundamentals/nervos-blockchain.md
@@ -2,7 +2,7 @@
 id: nervos-blockchain
 title: Nervos Blockchain
 description: "Get a beginner overview of Nervos CKB as a layered, proof-of-work blockchain for CKBytes, on-chain state, and CKB-VM programs."
-tags:
+keywords:
   - concept
   - layer-1
   - ckb-vm

--- a/website/docs/dapp/create-dob.mdx
+++ b/website/docs/dapp/create-dob.mdx
@@ -2,7 +2,7 @@
 id: create-dob
 title: Create a DOB
 description: "Build a dApp that uses the Spore protocol to turn user-provided content into an immutable on-chain digital object on CKB."
-tags:
+keywords:
   - dapp
   - tutorial
   - spore

--- a/website/docs/dapp/create-token.mdx
+++ b/website/docs/dapp/create-token.mdx
@@ -2,7 +2,7 @@
 id: create-token
 title: Create a Fungible Token
 description: "Issue and query a custom fungible token on CKB using the xUDT standard, Type Scripts, Cell data, and the CCC SDK."
-tags:
+keywords:
   - dapp
   - tutorial
   - xudt

--- a/website/docs/dapp/simple-lock.mdx
+++ b/website/docs/dapp/simple-lock.mdx
@@ -2,7 +2,7 @@
 id: simple-lock
 title: Build a Simple Lock
 description: "Build a full-stack CKB dApp with a simple hash Lock Script, Script deployment, frontend integration, and token unlocking flow."
-tags:
+keywords:
   - dapp
   - tutorial
   - script

--- a/website/docs/dapp/transfer-ckb.mdx
+++ b/website/docs/dapp/transfer-ckb.mdx
@@ -2,7 +2,7 @@
 id: transfer-ckb
 title: Transfer CKB
 description: "Build a simple dApp that generates accounts, checks CKB balances, creates a transfer transaction, pays fees, and broadcasts it."
-tags:
+keywords:
   - dapp
   - tutorial
   - ccc

--- a/website/docs/dapp/write-message.mdx
+++ b/website/docs/dapp/write-message.mdx
@@ -2,7 +2,7 @@
 id: store-data-on-cell
 title: Store Data on Cell
 description: "Build a dApp that writes a text message into CKB Cell data, then reads the Live Cell back and decodes the stored value."
-tags:
+keywords:
   - dapp
   - tutorial
   - cell-data

--- a/website/docs/getting-started/how-ckb-works.mdx
+++ b/website/docs/getting-started/how-ckb-works.mdx
@@ -2,7 +2,7 @@
 id: how-ckb-works
 title: How CKB Works
 description: "Learn how CKB uses Cells, Scripts, transactions, CKB-VM, and proof-of-work consensus to secure and update on-chain state."
-tags:
+keywords:
   - concept
   - cell-model
   - script

--- a/website/docs/getting-started/quick-start.mdx
+++ b/website/docs/getting-started/quick-start.mdx
@@ -2,7 +2,7 @@
 id: quick-start
 title: Quick Start (5min)
 description: "Set up a local CKB devnet with OffCKB and choose the right next path for building dApps, scripts, nodes, or core concepts."
-tags:
+keywords:
   - getting-started
   - devnet
   - offckb

--- a/website/docs/getting-started/rpcs.mdx
+++ b/website/docs/getting-started/rpcs.mdx
@@ -2,7 +2,7 @@
 id: rpcs
 title: RPCs
 description: "Connect to CKB JSON-RPC endpoints, use public RPC nodes safely, and call common methods such as get_tip_block_number and send_transaction."
-tags:
+keywords:
   - rpc
   - node
   - json-rpc

--- a/website/docs/node/install-ckb.mdx
+++ b/website/docs/node/install-ckb.mdx
@@ -2,7 +2,7 @@
 id: install-ckb
 title: Install CKB
 description: "Install the CKB binary from releases, source, or Docker, then proceed to Mainnet, Testnet, or Docker node setup."
-tags:
+keywords:
   - node
   - install
   - mainnet

--- a/website/docs/script/intro-to-script.mdx
+++ b/website/docs/script/intro-to-script.mdx
@@ -2,7 +2,7 @@
 id: intro-to-script
 title: "Intro to Script"
 description: "Learn what CKB Scripts are, how Lock Scripts and Type Scripts execute, and how code_hash, hash_type, and args locate Script code."
-tags:
+keywords:
   - script
   - concept
   - lock-script

--- a/website/docs/script/rust/rust-quick-start.mdx
+++ b/website/docs/script/rust/rust-quick-start.mdx
@@ -2,7 +2,7 @@
 id: rust-quick-start
 title: "Quick Start"
 description: "Create, build, test, and debug CKB Scripts in Rust using the recommended project template, no_std setup, and local examples."
-tags:
+keywords:
   - script
   - tutorial
   - rust

--- a/website/docs/sdk-and-devtool/ccc.mdx
+++ b/website/docs/sdk-and-devtool/ccc.mdx
@@ -2,7 +2,7 @@
 id: ccc
 title: JavaScript/TypeScript (CCC)
 description: "Use the CCC TypeScript SDK to compose transactions, connect wallets, sign messages, issue assets, and build CKB applications."
-tags:
+keywords:
   - ccc
   - typescript
   - sdk

--- a/website/docs/tech-explanation/transaction.md
+++ b/website/docs/tech-explanation/transaction.md
@@ -2,7 +2,7 @@
 id: transaction
 title: Transaction
 description: "Reference the CKB transaction structure, including cell_deps, header_deps, inputs, witnesses, outputs, outputs_data, and transaction states."
-tags:
+keywords:
   - transaction
   - reference
   - cell-model


### PR DESCRIPTION
## Summary

Replaces native Docusaurus docs frontmatter tags with keywords on important docs pages.

## Changes

- Converts 15 docs pages from tags to keywords metadata
- Keeps the metadata useful for search/AI context without rendering clickable tag chips
- Removes generated docs tag archive routes from the build output