### PR TITLE
fix: add redirects for old /docs/basics/concepts paths

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -173,6 +173,26 @@ const config = {
             to: "/docs/assets-token-standards/economics",
           },
           {
+            from: "/docs/basics/concepts/cell-model",
+            to: "/docs/ckb-fundamentals/cell-model",
+          },
+          {
+            from: "/docs/basics/concepts/ckb-vm",
+            to: "/docs/ckb-fundamentals/ckb-vm",
+          },
+          {
+            from: "/docs/basics/concepts/consensus",
+            to: "/docs/ckb-fundamentals/consensus",
+          },
+          {
+            from: "/docs/basics/concepts/cryptowallet",
+            to: "/docs/integrate-wallets/intro-to-wallets",
+          },
+          {
+            from: "/docs/basics/concepts/nervos-blockchain",
+            to: "/docs/ckb-fundamentals/nervos-blockchain",
+          },
+          {
             from: "/docs/basics/glossary/",
             to: "/docs/tech-explanation/glossary",
           },


### PR DESCRIPTION
## Summary

This PR adds Docusaurus client-side redirects for concept pages that were moved from <code>/docs/basics/concepts/*</code> to <code>/docs/ckb-fundamentals/*</code> during the docs restructure.

## Changes

Added redirects for the following old paths:

| Old path | Redirect target |
|---|---|
| <code>/docs/basics/concepts/cell-model</code> | <code>/docs/ckb-fundamentals/cell-model</code> |
| <code>/docs/basics/concepts/ckb-vm</code> | <code>/docs/ckb-fundamentals/ckb-vm</code> |
| <code>/docs/basics/concepts/consensus</code> | <code>/docs/ckb-fundamentals/consensus</code> |
| <code>/docs/basics/concepts/cryptowallet</code> | <code>/docs/integrate-wallets/intro-to-wallets</code> |
| <code>/docs/basics/concepts/nervos-blockchain</code> | <code>/docs/ckb-fundamentals/nervos-blockchain</code> |

Note: <code>/getting-started/wallet</code> already redirects to <code>/docs/integrate-wallets/intro-to-wallets</code>, so no additional change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)