### PR TITLE
docs: add CKB-VM internals series from Nervos Talk

### DIFF
--- a/website/docs/ckb-fundamentals/ckb-vm-internals/assembly-executor.mdx
+++ b/website/docs/ckb-fundamentals/ckb-vm-internals/assembly-executor.mdx
@@ -1,0 +1,333 @@
+---
+title: CKB-VM Assembly Executor
+---
+
+In early 2026, we introduced the third assembly execution backend for CKB-VM: [riscv64](https://github.com/nervosnetwork/ckb-vm/pull/502). Together with the earlier [x64](https://github.com/nervosnetwork/ckb-vm/blob/develop/src/machine/asm/execute_x64.S) and [aarch64](https://github.com/nervosnetwork/ckb-vm/blob/develop/src/machine/asm/execute_aarch64.S), CKB-VM can now execute RISC-V programs with hand-written assembly on three major CPU architectures. After shipping all three architecture paths, the core design ideas are now very clear and worth a full review.
+
+This article starts from the motivation behind CKB-VM’s assembly executor, then walks through technical details such as the trace mechanism, register allocation, and memory model. By the end, you should have a complete mental model of how the CKB-VM assembly executor works.
+
+## Why We Still Need an Assembly Executor
+
+CKB-VM is a RISC-V virtual machine. The most straightforward implementation is, of course, an interpreter: fetch, decode, execute, update PC and loop. This model is simple enough and naturally serves as a golden reference for correctness.
+
+But here is the problem: for on-chain scripts, each RISC-V instruction does very little work. For example, an `add` just adds one register to another and writes the result back. On the host CPU, that may take one or two instructions, but in the interpreter it goes through a Rust loop and match branch, reads the register array, checks whether `x0` is the write target, accumulates cycle counters, and jumps back to the top of the loop. After tens of millions of such round trips, fixed overhead becomes significant.
+
+One classic theme in interpreter optimization is **reducing dispatch**. Move the hottest loop path from a high-level language down into assembly, and strip away unnecessary abstraction layers. That is the fundamental motivation for the ASM backend.
+
+> Reducing dispatch is a classic interpreter optimization strategy, and you can see it heavily used in interpreter ecosystems such as LuaJIT and Python. Common techniques include adaptive/tiered interpreters, superinstructions/macro-op fusion, and direct threaded code.
+
+However, one common misunderstanding should be cleared up first: CKB-VM’s ASM backend is not a JIT. It never translates user RISC-V programs into new host machine code. It is still an interpreter, except that hot paths such as the dispatch loop, register access, and memory permission checks are handled by hand-written assembly.
+
+## Trace: Decode Once, Execute Many Times
+
+A traditional interpreter skeleton looks like this:
+
+```rust
+loop {
+    let inst = fetch_instruction();
+    match inst.opcode() {
+        OP_ADD => { /* ... */ }
+        OP_SUB => { /* ... */ }
+        OP_MUL => { /* ... */ }
+        // ... hundreds of branches
+    }
+}
+```
+
+At its core, this is a giant loop wrapped around a giant match. The issue is not only the number of match branches, but also that a CPU branch predictor can hardly make useful predictions on such a jump table. Every time execution returns from `OP_ADD` to the `match` at the loop top, it is a potential pipeline flush.
+
+> From a systems perspective, centralized interpreter dispatch creates many-to-one control-flow convergence, which destroys the regular patterns branch predictors depend on. There are two major problems:
+>
+> Single Exit Disaster: In an interpreter loop, all bytecode instructions are dispatched through one match or switch site. From the predictor’s point of view, the jump source address is always the same, while the target address can be any handler.
+>
+> Branch aliasing: Modern predictors (for example, TAGE or Perceptron-based designs) rely on structures like BHT and BTB. If one jump instruction keeps switching randomly among dozens or hundreds of states, the predictor cannot extract stable history patterns (alternation, cycles, etc.), and prediction accuracy collapses. Every misprediction can cause a 10-20 cycle pipeline flush.
+
+LuaJIT author Mike Pall proposed a simple idea: instead of re-matching opcodes every time, **record** frequently sequential instruction sequences. This pre-decoded linear sequence is called a trace. With a trace, the execution path is no longer loop → match → opcode_handler → loop, but direct jumps along a pre-arranged label chain.
+
+In pseudocode:
+
+```auto
+OP_CUSTOM_TRACE_END:
+    trace = fetch_trace(pc)          // for example [OP_ADD, OP_SUB, OP_MUL, OP_CUSTOM_TRACE_END]
+    index = 0
+    goto trace[index].label          // jump to OP_ADD
+
+OP_ADD:
+    index += 1
+    handle_add(trace[index].args)    // execute OP_ADD
+    goto trace[index].label          // jump to OP_SUB
+
+OP_SUB:
+    index += 1
+    handle_sub(trace[index].args)    // execute OP_SUB
+    goto trace[index].label          // jump to OP_MUL
+
+OP_MUL:
+    index += 1
+    handle_mul(trace[index].args)    // execute OP_MUL
+    goto trace[index].label          // jump back to OP_CUSTOM_TRACE_END, start loading next trace
+```
+
+LuaJIT further compiles traces into machine code. CKB-VM does not compile, but it borrows the same front-end step: pre-decode an instruction sequence on the Rust side and build a trace. Each trace item contains two `u64` values; in CKB-VM these two numbers are called a thread:
+
+| Offset         | Content             | Meaning                                                                               |
+| -------------- | ------------------- | ------------------------------------------------------------------------------------- |
+| `thread[2n]`   | label address       | Absolute address of a host assembly label, for example `.CKB_VM_ASM_LABEL_OP_ADD`     |
+| `thread[2n+1]` | decoded instruction | Decoded instruction parameters; register indices and immediates are already extracted |
+
+Inside the assembly executor, this structure is driven by two pointers:
+
+- `INST_PC`: points to the label address of the current thread.
+- `INST_ARGS`: points to the decoded instruction payload of the current thread.
+
+After executing one instruction, the `NEXT_INST` macro advances both pointers by 16 bytes (one trace item), then jumps directly to the next assembly label via `jmp *INST_PC`. A dispatch round is completed with just a few instructions. No loop, no match, no branch-prediction pressure. The per-instruction decode and dispatch cost is folded into trace construction ahead of time. The execution phase only needs to load an address and jump.
+
+**Source Reading**
+
+- [traces.rs](https://github.com/nervosnetwork/ckb-vm/blob/develop/src/machine/asm/traces.rs)
+- [execute_x64.S](https://github.com/nervosnetwork/ckb-vm/blob/develop/src/machine/asm/execute_x64.S)
+
+The trace design is the foundation of the CKB-VM ASM executor, and also one of the hardest parts of the project to understand.
+
+## Trace: Fixed and Dynamic
+
+CKB-VM’s trace system has two layers.
+
+**Fixed Trace** is the default implementation. It maintains a hash table of size 8192 in memory, using `slot = (PC >> 2) & 8191` to locate a slot. Each slot is a `FixedTrace` structure that can hold up to 16 instructions (plus a trailing `OP_CUSTOM_TRACE_END`, for a total of 17 threads). When the program executes within a basic block, these instructions are decoded together and executed together until a branch or trace end is reached.
+
+Fixed trace is enough for most scenarios. But for longer sequential code blocks, 16 instructions may not be enough. In that case, the trace decoder has two strategies:
+
+1. If there is nothing after it, end normally and return to `OP_CUSTOM_TRACE_END` next time for another table lookup.
+2. If more consecutive instructions remain (that is, the currently decoded instruction is not a basic-block terminator), the decoder builds a **Dynamic Trace**.
+
+Dynamic Trace is a variable-length structure using a [flexible array member](https://en.wikipedia.org/wiki/Flexible_array_member), which can encode an entire long sequential segment at once, not limited to 16 instructions. At the assembly layer, it looks **exactly the same** as FixedTrace: `address`, `length`, `cycles`, followed by the same thread sequence format.
+
+The two are connected as follows: the final thread of a fixed trace is replaced with `OP_CUSTOM_ASM_TRACE_JUMP`, and its argument is the full dynamic-trace address. When the assembly executor sees this opcode, it switches the `TRACE` pointer directly to the dynamic trace, then reuses the same `.trace_loaded` logic. Rust builds two different data structures, but assembly sees one unified shape.
+
+> The key to this uniformity is that the first three fields of DynamicTrace have exactly the same memory layout as FixedTrace. Assembly accesses them using the same offset macros (`CKB_VM_ASM_TRACE_OFFSET_ADDRESS`, `CKB_VM_ASM_TRACE_OFFSET_LENGTH`, `CKB_VM_ASM_TRACE_OFFSET_CYCLES`). There are dedicated unit tests in the source to verify this invariant.
+
+## Trace: How Rust Passes It to Assembly
+
+The ASM executor entry has only two parameters:
+
+```rust
+ckb_vm_asm_execute(machine, invoke_data)
+```
+
+`machine` is `AsmCoreMachine`, which stores VM state such as registers, PC, cycles, memory pointer, page flags, and frame flags. `invoke_data` is call-local data passed to assembly, whose key members include `pause`, `fixed_traces`, and `fixed_trace_mask`.
+
+At the assembly entry point, it first does a very conventional thing: save the callee-saved registers required by the calling convention, then pin several long-lived values in registers.
+
+````auto
+ckb_vm_asm_execute:
+  push %rbp
+  push %rbx
+  push %r12
+  push %r13
+  push %r14
+  mov ARG2, INVOKE_DATA     // 2nd argument -> INVOKE_DATA
+  mov ARG1, MACHINE         // 1st argument -> MACHINE
+  movq CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_MEMORY_SIZE(MACHINE), MEMORY_SIZE
+``` ```auto
+MACHINE     = %rsi
+TRACE       = %rbx
+MEMORY_SIZE = %r13
+INVOKE_DATA = %r14
+INST_PC     = %r8
+INST_ARGS   = %r9
+````
+
+`MACHINE` holds all VM state. `TRACE` points to the currently executing trace. `INST_PC` and `INST_ARGS` are not the RISC-V PC, but two pointers moving inside a trace: one to the next host jump target, one to the next decoded guest instruction payload.
+
+This is also where x64 gets tricky. `%rcx` must be reserved for shift operations via `%cl`, `%rax/%rdx` are consumed by multiply/divide instructions, and Windows/System V use different argument registers. That is why there is a large section of register aliases and macros like `PUSH_*_IF_*` at the top of the file. It looks verbose, but it reserves room for the next 2000+ lines of instruction implementations.
+
+Aarch64 and riscv64 have similar entry logic but with different flavor: aarch64 has more register headroom, so secondary yet frequently used pointers like `REGISTER_BASE` and `MEMORY_PTR` can stay in `x28`, `x29`. Riscv64 feels like looking in a mirror: host and guest are both RISC-V, so many guest instructions map directly to host instructions, but it still must obey host ABI, preserve `s0..s6`, and return the assembly execution result through `a0`.
+
+## Trace: Entry Is Exit, Exit Is Entry
+
+After entering the assembly main loop, execution first goes to `.CKB_VM_ASM_LABEL_OP_CUSTOM_TRACE_END`. This is a somewhat complex block:
+
+```auto
+.p2align 3
+.CKB_VM_ASM_LABEL_OP_CUSTOM_TRACE_END:
+  LOAD_PC(%rax, %eax, %rcx, %ecx, TEMP3d)
+  shr $2, %eax
+  andq CKB_VM_ASM_INVOKE_DATA_OFFSET_FIXED_TRACE_MASK(INVOKE_DATA), %rax
+  imul $CKB_VM_ASM_FIXED_TRACE_STRUCT_SIZE, %eax
+  movq CKB_VM_ASM_INVOKE_DATA_OFFSET_FIXED_TRACES(INVOKE_DATA), TRACE
+  addq %rax, TRACE
+  movq CKB_VM_ASM_TRACE_OFFSET_ADDRESS(TRACE), %rdx
+  cmp %rcx, %rdx
+  jne .exit_trace
+.trace_loaded:
+  mov CKB_VM_ASM_TRACE_OFFSET_LENGTH(TRACE), %edx
+  test %rdx, %rdx
+  je .exit_trace
+  movq CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_CYCLES(MACHINE), %rax
+  addq CKB_VM_ASM_TRACE_OFFSET_CYCLES(TRACE), %rax
+  jc .exit_cycles_overflow
+  cmp CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_MAX_CYCLES(MACHINE), %rax
+  ja .exit_max_cycles_exceeded
+  movq %rax, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_CYCLES(MACHINE)
+  addq %rdx, PC_ADDRESS
+  /* Prefetch trace info for the consecutive block */
+  movq PC_ADDRESS, %rax
+  shr $2, %eax
+  andq CKB_VM_ASM_INVOKE_DATA_OFFSET_FIXED_TRACE_MASK(INVOKE_DATA), %rax
+  imul $CKB_VM_ASM_FIXED_TRACE_STRUCT_SIZE, %eax
+  movq CKB_VM_ASM_INVOKE_DATA_OFFSET_FIXED_TRACES(INVOKE_DATA), %rdx
+  prefetcht2 0(%rdx, %rax)
+  lea CKB_VM_ASM_TRACE_OFFSET_THREADS(TRACE), INST_PC
+  mov INST_PC, INST_ARGS
+  add $8, INST_ARGS
+  NEXT_INST
+```
+
+This block does not mean the program has ended. It means the current trace has reached its end and **must decide where to go next**. It may jump to the next trace, or return to Rust for re-decoding. On first entry into the assembly executor, this same logic also runs first, because in essence it is the unified entry for “load next trace and start execution”.
+
+Its core flow can be summarized in four steps:
+
+1. Use current PC to locate a slot in the fixed-trace table.
+2. Verify the trace start address in that slot matches current PC.
+3. Check that trace length and cycle budget allow continued execution.
+4. On success, switch to the new trace and `NEXT_INST`; on failure, go to `.exit_trace` and return `CKB_VM_ASM_RET_DECODE_TRACE`. Rust will decode again based on this return value, build a new trace, and call the assembly executor again.
+
+There are two easy-to-miss details.
+
+First, fixed traces are not chained directly by “next instruction in current trace.” Instead, each time it re-hashes the updated PC into the fixed-trace table and revalidates `trace.address == pc`. This guarantees that even with hash collisions or slot mismatch, execution safely returns to Rust for decoding, rather than jumping into a wrong trace.
+
+Second, `.CKB_VM_ASM_LABEL_OP_CUSTOM_ASM_TRACE_JUMP` loads the full trace address from thread arguments into `TRACE`, then reuses the same `.trace_loaded` logic. In other words, dynamic trace and fixed trace share the exact same execution-phase flow: length check + cycle accounting + setting `INST_PC/INST_ARGS`; only the source of the trace pointer differs.
+
+The significance of this block is that it centralizes the decision of whether to keep sprinting in assembly: if address matches, length is valid, and cycles are legal, continue thread dispatch; if any condition fails, return to Rust immediately. This gives the assembly executor both high-speed paths and correctness on edge conditions.
+
+## Zero Register
+
+In RISC-V, `x0` is always zero. This rule is simple, but in an executor implementation it can easily become a subtle trap.
+
+In early versions, the CKB-VM ASM backend often wrote back to `rd` and then zeroed register slot 0 in the register array. So macros like this appeared:
+
+```nasm
+#define WRITE_RD(v) \
+  movq v, REGISTER_ADDRESS(RD); \
+  movq $0, ZERO_ADDRESS
+```
+
+That means even if an instruction mistakenly wrote to `x0`, the next step would erase it. Later, some MOP pseudo-instructions wrote multiple registers within one guest semantic unit. If `x0` was zeroed immediately after each write, write-back order itself could affect results. So the source later introduced the `WRITE_RD_V2` and `NEXT_INST_V2` macro pair: the former only writes target registers, and the latter zeros `x0` once at the end of the whole pseudo-instruction.
+
+## Memory Checks
+
+If you only look at arithmetic instructions, the assembly executor is not hard to understand. `add` is just loading two registers, adding them, and writing back. What truly makes it complex is memory.
+
+CKB-VM’s memory model must reject out-of-bounds accesses, enforce W^X permissions, and support lazily initialized FastMemory. Every `lb`, `lw`, `ld`, `sb`, `sw`, `sd` may trigger this whole logic chain. If these checks are too slow, most ASM backend gains get eaten. If they are too aggressive, on-chain determinism and safety boundaries are compromised.
+
+All three assembly executors use a similar strategy: remember the last accessed memory frame for reads, or last written page for writes. If current access is still within the same range, take the fast path directly; if crossing boundaries, fall back to full checks.
+
+The read path is roughly three steps:
+
+- Check whether address plus length overflows bounds.
+- Check whether the corresponding memory frame is initialized.
+- If uninitialized, call Rust-side `inited_memory` to perform actual fill.
+
+The write path adds one more permission layer: the target page must be writable, and the dirty bit must be set so snapshots and later memory management know this page was modified.
+
+The most noteworthy detail here is `PREPCALL` and `POSTCALL`. Most of the time, the assembly executor does not want to return to Rust land, but tasks like memory initialization are still handled by Rust. Once a call to `inited_memory` is needed, assembly must save current register state, align stack according to target ABI, call the function, then restore context. This sounds like a basic ABI rule, but in a hand-written executor, missing one such rule often leads to very weird bugs.
+
+## If We Were to Build the Next ASM Executor
+
+Suppose one day we add a new host architecture for CKB-VM. Where should we start?
+
+Historically, CKB-VM has had three ASM executors: x64, aarch64, and riscv64. After finishing all three paths, the implementation recipe is quite clear. Here is the rough process I summarize.
+
+**Step 1: Understand Data Structures and Contracts**
+
+First, read through these three structs:
+
+- `AsmCoreMachine`: C layout of VM state. Assembly accesses fields via `CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_*` macros.
+- `InvokeData`: three pointers passed to assembly (`pause`, `fixed_traces`, `fixed_trace_mask`).
+- `FixedTrace`: trace memory layout: `address`, `length`, `cycles`, then a thread array of `2 * (TRACE_ITEM_LENGTH + 1)` `u64` values.
+
+These offset macros are not hand-written. They are auto-generated at build time by `definitions/src/generate_asm_constants.rs` into `cdefinitions_generated.h`. **Never maintain these offsets manually** , or one struct layout change will break everything.
+
+**Step 2: Build the Minimal Skeleton**
+
+Start with this minimal skeleton in assembly:
+
+```nasm
+ckb_vm_asm_execute:
+    save callee-saved registers
+    pin arguments into MACHINE / INVOKE_DATA
+    load MEMORY_SIZE
+    jump to OP_CUSTOM_TRACE_END
+```
+
+Then implement full `OP_CUSTOM_TRACE_END` logic immediately: lookup fixed trace, compare address, check cycles, set `INST_PC`/`INST_ARGS`, `NEXT_INST`.
+
+At the same time, wire up the label table. Rust calculates label addresses through `label_from_fastpath_opcode()`:
+
+```rust
+pub fn label_from_fastpath_opcode(opcode: InstructionOpcode) -> u64 {
+    unsafe {
+        u64::from(*(ckb_vm_asm_labels as *const u32).offset(opcode as u8 as isize))
+            + (ckb_vm_asm_execute as *const u32 as u64)
+    }
+}
+```
+
+`ckb_vm_asm_labels` is a symbol defined in the assembly file. It is actually a `u32` array, where each element is the offset of an opcode label relative to the `ckb_vm_asm_execute` entry address. As long as the skeleton runs, even with only `OP_CUSTOM_TRACE_END`, you have already crossed the most critical milestone.
+
+**Step 3: Register Allocation**
+
+This is the hardest part, arguably harder than implementing instructions themselves. The three backends use different allocation strategies:
+
+- **x64** : constrained by `%cl` for shifts and `%rax/%rdx` for multiply/divide; `RS2` is split, and `RD` shares `%rax` with `RS2`.
+- **aarch64** : more register headroom; only `xzr` cannot be used as a general-purpose register; extensive use of callee-saved registers is possible.
+- **riscv64** : both host and guest follow RISC-V ABI; use callee-saved `s0s6` to hold guest register state, reducing `PREPCALL`/`POSTCALL` save/restore scope.
+
+A few general principles for allocation:
+
+1. Put long-lived pointers (`MACHINE`, `TRACE`, `INST_PC`, `INST_ARGS`) in callee-saved registers so no restore is needed after `inited_memory` calls.
+2. Direct decode results (`RD`, `RS1`, `RS2`, `IMMEDIATE`) can be in caller-saved or callee-saved registers, but pay attention to read/write density.
+3. If a register has architecture-specific constraints (for example, x64 requiring `%rcx` for `IMMEDIATE`), satisfy those constraints first.
+
+**Step 4: Write Memory Macros**
+
+Memory macros should be stabilized before instruction families. Arithmetic bugs are usually easy to catch; memory-boundary bugs may surface only under cross-page access, specific VM versions, or random memory layouts in chaos mode. These bugs are very expensive to debug.
+
+A recommended implementation order:
+
+1. `_CHECK_READ_FRAMES`: internal macro for memory-frame initialization.
+2. `CHECK_READ_VERSION0` / `CHECK_READ_VERSION1`: bounds check plus `last_read_frame` caching.
+3. `CHECK_WRITE`: W^X check plus dirty marking plus frame initialization.
+4. `PREPCALL` / `POSTCALL`: ensure Rust call ABI correctness.
+
+**Step 5: Implement by Instruction Families**
+
+- First wave: base integer instructions in I, load/store, branch/jump. These form the main body of programs.
+- Second wave: M (mul/div). Focus on arithmetic edge cases (`INT64_MIN / -1`, division by zero).
+- Third wave: B (bitmanip) and MOP (macro-fusion ops). Focus on multi-register write-back and `x0` zeroing timing.
+
+**Step 6: Test**
+
+After each instruction group is added, it should run the same artifact set as the normal interpreter. CKB-VM currently has a complete test suite; for developers, passing `cargo test --features=asm` generally means the assembly executor is mostly correct.
+
+Also, CKB-VM’s fuzzing framework (`fuzz/fuzz_targets/asm.rs`) is a key correctness tool: it generates random instruction streams, executes them on ASM and interpreter backends respectively, then compares all registers and memory states.
+
+## Summary
+
+CKB-VM’s assembly executor is a restrained optimization. It does not introduce JIT, does not change on-chain program semantics, and does not hand safety boundaries to a host-code generator. What it does is more straightforward and more demanding: translate the interpreter’s hottest paths into hand-written assembly instruction by instruction, while preserving CKB-VM’s memory model, version semantics, cycle accounting, and exception behavior.
+
+From the Rust interpreter to x64 assembly, then aarch64 assembly, and finally riscv64 assembly, this path demonstrates an engineering tradeoff very characteristic of CKB-VM: build a clear reference implementation first, then make verifiable local replacements on hot paths. Each new backend is not a rewrite, but a retelling of the same loop under the same semantics, in the target architecture’s own language.
+
+That is what I like most about this design. The assembly executor looks complex, obscure, and hard to understand, but the goal it serves is simple: make on-chain programs run faster without sacrificing determinism and safety. For a blockchain VM, that is already both a plain and a very difficult goal.
+
+## Series of articles
+
+- [Deep Dive into CKB-VM Snapshot V1: Architecture and Design Principles](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366)
+- [Deep Dive into CKB-VM Snapshot V2: Evolution](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v2-evolution/10367)
+- [Deep Dive into CKB-VM Memory Model: Design of W^X](https://talk.nervos.org/t/deep-dive-into-ckb-vm-memory-model-design-of-w-x/10398)
+- [Deep Dive into CKB-VM Assembly Executor](https://talk.nervos.org/t/deep-dive-into-ckb-vm-assembly-executor/10441)
+- [Deep Dive Into CKB-VM Macro-ops Fusion](https://talk.nervos.org/t/deep-dive-into-ckb-vm-macro-ops-fusion/10468)
+
+---
+
+_This article is adapted from [Deep Dive into CKB-VM Assembly Executor](https://talk.nervos.org/t/deep-dive-into-ckb-vm-assembly-executor/10441) by [mohanson](https://talk.nervos.org/u/mohanson) on Nervos Talk._

--- a/website/docs/ckb-fundamentals/ckb-vm-internals/macro-ops-fusion.mdx
+++ b/website/docs/ckb-fundamentals/ckb-vm-internals/macro-ops-fusion.mdx
@@ -1,0 +1,151 @@
+---
+title: CKB-VM Macro-ops Fusion
+---
+
+## Overview
+
+Macro-Operation Fusion (MOP Fusion) is a performance optimization technique used in modern microprocessor architectures. During instruction decode, several adjacent macro-operations are merged into a single internal micro-operation, reducing dispatch overhead and execution cycles. This technique is widely used in high-performance microarchitectures for mainstream architectures such as x86 and ARM, and it can also be implemented at the virtual-machine layer through the decoder. The following example illustrates the principles and benefits of MOP fusion.
+
+Take signed division as an example. Suppose we want to compute 100 / 42 and obtain both the quotient and the remainder. The corresponding RISC-V assembly looks like this:
+
+```auto
+addi t0, t0, 100 # Load 100 into register t0
+
+addi t1, t1, 42 # Load 42 into register t1
+
+div a0, t0, t1 # Calc 100 / 42, store the result into a0
+
+rem a1, t0, t1 # Calc 100 % 42, store the result into a1
+```
+
+In normal execution mode, CKB-VM executes `div` and `rem` as two independent instructions. However, there is optimization potential here. The ASM backend of CKB-VM runs on an x86-64 host machine, and the x86-64 `IDIV` instruction produces both quotient and remainder when performing signed division ([reference manual](https://c9x.me/x86/html/file_module_x86_id_72.html)). Therefore, when `div` and `rem` appear adjacent to each other and both operands are exactly the same, we can fuse these two RISC-V instructions into a single internal pseudo-instruction. That internal instruction maps to one x86-64 `IDIV` instruction instead of two, substantially reducing execution cycles.
+
+CKB-VM introduced macro-operation fusion in the 2021 Edition hard fork, and expanded the fusion rule set further in the 2023 Edition. During decoding, CKB-VM checks whether adjacent instruction sequences satisfy the fusion conditions, and if so, merges them into a single internal instruction. These internal instructions usually correspond to just one native instruction in the x86-64 backend, rather than the multiple instructions that existed before fusion.
+
+The set of supported macro-fusion rules in CKB-VM has been expanded gradually across versions. There are currently 16 fusion rules in total. After fusion, the execution cycle count of the fused instruction equals the highest cycle count among the original instructions in the sequence, while the remaining instructions are reduced to zero cycles. The following sections describe the fusion rules introduced by the two hard forks.
+
+### CKB 2021 Edition
+
+**ADC** : Add with Carry, 5 instructions, cycle cost 1. Used for the low-word computation in 128-bit integer addition: it adds two 64-bit values and propagates the carry.
+
+[![adc](https://talk.nervos.org/uploads/default/original/2X/3/3406f9fa9c3bf851671bbd605d0785e84bb49cb7.svg)adc960×440 2.16 KB](https://talk.nervos.org/uploads/default/original/2X/3/3406f9fa9c3bf851671bbd605d0785e84bb49cb7.svg "adc")
+
+**SBB** : Subtract with Borrow, 5 instructions, cycle cost 1. Used for the low-word computation in 128-bit integer subtraction: it subtracts two 64-bit values and propagates the borrow.
+
+[![sbb](https://talk.nervos.org/uploads/default/original/2X/d/dee1e03da632d4fb2e5447e303940493da928bd7.svg)sbb960×440 2.16 KB](https://talk.nervos.org/uploads/default/original/2X/d/dee1e03da632d4fb2e5447e303940493da928bd7.svg "sbb")
+
+**WIDE_MUL** : Signed wide multiplication, 2 instructions, cycle cost 5. Computes both the high 64 bits and low 64 bits of the product of two signed 64-bit integers, yielding the full 128-bit result.
+
+[![wide_mul](https://talk.nervos.org/uploads/default/original/2X/e/e48ba68208d6e10becf7ce93481c3df6f2e060e5.svg)wide_mul960×400 1.9 KB](https://talk.nervos.org/uploads/default/original/2X/e/e48ba68208d6e10becf7ce93481c3df6f2e060e5.svg "wide_mul")
+
+**WIDE_MULU** : Unsigned wide multiplication, 2 instructions, cycle cost 5.
+
+[![wide_mulu](https://talk.nervos.org/uploads/default/original/2X/5/57e750daff6b40d90f8540831af84c100af8e50a.svg)wide_mulu960×400 1.9 KB](https://talk.nervos.org/uploads/default/original/2X/5/57e750daff6b40d90f8540831af84c100af8e50a.svg "wide_mulu")
+
+**WIDE_MULSU** : Signed/unsigned wide multiplication, 2 instructions, cycle cost 5.
+
+[![wide_mulsu](https://talk.nervos.org/uploads/default/original/2X/3/3913a027171b6c4a7f81b363391f4ac625263ac1.svg)wide_mulsu960×400 1.93 KB](https://talk.nervos.org/uploads/default/original/2X/3/3913a027171b6c4a7f81b363391f4ac625263ac1.svg "wide_mulsu")
+
+**WIDE_DIV** : Signed wide division, 2 instructions, cycle cost 32. Computes both the quotient and remainder of signed division, corresponding to the single x86-64 `IDIV` instruction.
+
+[![wide_div](https://talk.nervos.org/uploads/default/original/2X/1/17cc38065c478ed74091e85348b1ee7cb0c339bc.svg)wide_div960×400 1.9 KB](https://talk.nervos.org/uploads/default/original/2X/1/17cc38065c478ed74091e85348b1ee7cb0c339bc.svg "wide_div")
+
+**WIDE_DIVU** : Unsigned wide division, 2 instructions, cycle cost 32.
+
+[![wide_divu](https://talk.nervos.org/uploads/default/original/2X/3/30b54e6a0c2a6997480de792fbc27ef682ee84c4.svg)wide_divu960×400 1.91 KB](https://talk.nervos.org/uploads/default/original/2X/3/30b54e6a0c2a6997480de792fbc27ef682ee84c4.svg "wide_divu")
+
+**FAR_JUMP_REL** : PC-relative far jump, 2 instructions, cycle cost 3. Used to call functions whose offsets exceed the range reachable by `jal` (+/-1 MiB).
+
+[![far_jump_rel](https://talk.nervos.org/uploads/default/original/2X/9/9b5c4658babd12693517477cca5ee1026d9ff03c.svg)far_jump_rel960×400 1.87 KB](https://talk.nervos.org/uploads/default/original/2X/9/9b5c4658babd12693517477cca5ee1026d9ff03c.svg "far_jump_rel")
+
+**FAR_JUMP_ABS** : Absolute-address far jump, 2 instructions, cycle cost 3.
+
+[![far_jump_abs](https://talk.nervos.org/uploads/default/original/2X/4/446ed5a5a53bad068c807d90cdd40f4f8c48034a.svg)far_jump_abs960×400 1.86 KB](https://talk.nervos.org/uploads/default/original/2X/4/446ed5a5a53bad068c807d90cdd40f4f8c48034a.svg "far_jump_abs")
+
+**LD_SIGN_EXTENDED_32_CONSTANT** : Load a 32-bit sign-extended immediate, 2 instructions, cycle cost 1. Loads a 32-bit sign-extended immediate into a register.
+
+[![ld_sign_extended_32_constant](https://talk.nervos.org/uploads/default/original/2X/2/20910bf98bd545328fff44ce29562469b41fa1b6.svg)ld_sign_extended_32_constant960×400 1.89 KB](https://talk.nervos.org/uploads/default/original/2X/2/20910bf98bd545328fff44ce29562469b41fa1b6.svg "ld_sign_extended_32_constant")
+
+### CKB 2023 Edition
+
+**ADCS** : Add with Carry Out (Overflowing Addition), 2 instructions, cycle cost 1. This is a simplified form of `ADC`: it performs one addition and simultaneously outputs the carry flag. It is also the basic building block of `ADD3A`/`ADD3B`/`ADD3C`.
+
+[![adcs](https://talk.nervos.org/uploads/default/original/2X/9/924cf3fbc9f07f4509c6f61e76907c35f5d8bb53.svg)adcs960×400 1.9 KB](https://talk.nervos.org/uploads/default/original/2X/9/924cf3fbc9f07f4509c6f61e76907c35f5d8bb53.svg "adcs")
+
+**SBBS** : Subtract with Borrow Out (Borrowing Subtraction), 2 instructions, cycle cost 1. This is a simplified form of `SBB`: it performs one subtraction and simultaneously outputs the borrow flag.
+
+[![sbbs](https://talk.nervos.org/uploads/default/original/2X/1/18275d2fa6c3ed6b9802ba708ad8f9d61a28ec8d.svg)sbbs960×400 1.87 KB](https://talk.nervos.org/uploads/default/original/2X/1/18275d2fa6c3ed6b9802ba708ad8f9d61a28ec8d.svg "sbbs")
+
+**ADD3A** : Carry-propagating addition variant A, 3 instructions, cycle cost 1. The addition result is written back to the register holding rs2, the carry flag is stored in an independent register, and then an extra carry-in is added.
+
+[![add3a](https://talk.nervos.org/uploads/default/original/2X/7/7c08007460285c804482ae8bfc7bd407cf45e877.svg)add3a960×440 2.17 KB](https://talk.nervos.org/uploads/default/original/2X/7/7c08007460285c804482ae8bfc7bd407cf45e877.svg "add3a")
+
+**ADD3B** : Carry-propagating addition variant B, 3 instructions, cycle cost 1. The carry flag is written back to the register holding rs1, and then added to the third operand.
+
+[![add3b](https://talk.nervos.org/uploads/default/original/2X/6/62611c5f198a0ae1de5b4654cde1806414aea3b7.svg)add3b960×440 2.13 KB](https://talk.nervos.org/uploads/default/original/2X/6/62611c5f198a0ae1de5b4654cde1806414aea3b7.svg "add3b")
+
+**ADD3C** : Carry-propagating addition variant C, 3 instructions, cycle cost 1. The carry flag is stored in an independent register and then the third operand is accumulated in place.
+
+[![add3c](https://talk.nervos.org/uploads/default/original/2X/0/04e167e58229a538e2f3d14c150342b1aa68e1e0.svg)add3c960×440 2.16 KB](https://talk.nervos.org/uploads/default/original/2X/0/04e167e58229a538e2f3d14c150342b1aa68e1e0.svg "add3c")
+
+**LD_SIGN_EXTENDED_32_CONSTANT (auipc variant)** : PC-relative address materialization, 2 instructions, cycle cost 1. CKB 2023 Edition adds `auipc + addi` to the same fusion opcode as `lui + addiw` (`LD_SIGN_EXTENDED_32_CONSTANT`), allowing PC-relative offsets to be materialized directly as immediate constants during decoding.
+
+[![ld_sign_extended_32_constant_auipc](https://talk.nervos.org/uploads/default/original/2X/8/8b9e3068892d85bd35016b93426a117b4eeef2f2.svg)ld_sign_extended_32_constant_auipc960×400 1.91 KB](https://talk.nervos.org/uploads/default/original/2X/8/8b9e3068892d85bd35016b93426a117b4eeef2f2.svg "ld_sign_extended_32_constant_auipc")
+
+## Performance Analysis
+
+The following benchmarks compare the CKB-VM ASM backend with MOP fusion enabled and disabled:
+
+- **asm** : ASM backend, MOP fusion disabled
+
+- **mop** : ASM backend, MOP fusion enabled
+
+All test targets are cryptographic algorithms commonly used on CKB. Criterion is used to measure the median cycle count across 100 samples. Note that the cycles in the table refer to the cycles spent executing CKB-VM on the host x86-64 CPU, not RISC-V instruction cycles. The comparison is as follows:
+
+| Algorithm         | asm (cycles) | mop (cycles) | Change     |
+| ----------------- | ------------ | ------------ | ---------- |
+| ed25519           | 9,508,012    | 8,804,419    | **-7.4%**  |
+| k256_ecdsa        | 37,225,290   | 36,353,859   | **-2.3%**  |
+| k256_schnorr      | 17,603,180   | 16,870,957   | **-4.2%**  |
+| p256              | 28,359,207   | 24,815,077   | **-12.5%** |
+| rsa               | 27,871,846   | 24,778,071   | **-11.0%** |
+| secp256k1_ecdsa   | 10,776,242   | 9,732,561    | **-9.7%**  |
+| secp256k1_schnorr | 10,465,140   | 9,308,162    | **-11.0%** |
+| sphincsplus_ref   | 279,791,883  | 327,076,711  | **+16.9%** |
+
+Almost all algorithms benefit from performance improvements when MOP is enabled; only one algorithm regresses. To analyze these changes, we counted the fused opcode types triggered by each algorithm after enabling MOP, as well as the proportion of MOP instructions among total executed instructions. The results are shown below:
+
+| Algorithm         | MOPs                                                                  | MOP instruction percentage (%) |
+| ----------------- | --------------------------------------------------------------------- | ------------------------------ |
+| ed25519           | WIDE_MULU(15876), ADCS(52946), ADD3B(1518)                            | 7.1635                         |
+| k256_ecdsa        | WIDE_MULU(63072), ADCS(56685), SBBS(488), ADD3B(1827), ADD3C(12152)   | 3.2395                         |
+| k256_schnorr      | WIDE_MULU(31389), ADCS(22439), SBBS(4), ADD3B(766), ADD3C(5490)       | 3.0162                         |
+| p256              | WIDE_MULU(87082), ADCS(414371), SBBS(4846), ADD3B(15903), ADD3C(262)  | 12.8793                        |
+| rsa               | WIDE_MULU(191533), ADCS(198216)                                       | 10.5770                        |
+| secp256k1_ecdsa   | WIDE_MUL(146), WIDE_MULU(11877), ADCS(53290), ADD3B(1146), ADD3C(613) | 13.7066                        |
+| secp256k1_schnorr | WIDE_MUL(64), WIDE_MULU(11672), ADCS(51557), ADD3B(1127), ADD3C(589)  | 13.6859                        |
+| sphincsplus_ref   | /                                                                     | 0                              |
+
+From the table above, we can see that the types and counts of fused opcodes triggered by each algorithm vary significantly after MOP is enabled, which also explains the differences in performance gains. For `sphincsplus_ref`, because it never triggers any fused opcode, performance regresses after enabling MOP. This is because the MOP decoder introduces extra work during decoding, but the instruction stream of this algorithm offers no fusion opportunities to offset that overhead, resulting in an overall slowdown.
+
+It is worth noting that all of the tests above use algorithm implementations written in Rust and C. Their compiler optimization strategies and generated instruction streams may not be fully aligned with the MOP fusion rules, so the actual performance may be limited by implementation details. In practice, hand-written assembly optimizations for hot code paths can make better use of MOP fusion, and the real performance gains may exceed the benchmark results above.
+
+You can find the complete benchmark code and data in [this repository](https://github.com/nervosnetwork/ckb-vm-contrib/tree/main/ckb-vm-test-suite/benches).
+
+## Conclusion
+
+The essence of MOP fusion in CKB-VM is to exchange a small amount of pattern-matching overhead during decoding for significant instruction-level gains during execution: when an instruction sequence satisfies the fusion conditions, multiple RISC-V instructions can be compressed into a single internal operation and mapped to a more efficient native instruction path on the host machine. From the 2021 Edition to the 2023 Edition, the fusion rules expanded from 10 to 16, covering common hotspot patterns such as large-integer addition, subtraction, multiplication, division, far jumps, and constant/address materialization. This is the core reason why on-chain cryptographic algorithms achieve overall acceleration.
+
+The benchmark results also show the limits of MOP’s benefit: it is not a universal accelerator, but an optimizer for specific patterns. Algorithms that frequently trigger fused opcodes can often obtain substantial speedups; if the fusion rules are rarely hit, the extra decoder overhead may instead cause a small regression. Therefore, in real engineering work, MOP should be considered together with code-generation strategy. By tuning compiler options or hand-writing hot assembly paths to proactively construct instruction sequences that are easier to fuse, it is possible to consistently unlock the performance potential of the CKB-VM ASM backend.
+
+## Series of articles
+
+- [Deep Dive into CKB-VM Snapshot V1: Architecture and Design Principles](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366)
+- [Deep Dive into CKB-VM Snapshot V2: Evolution](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v2-evolution/10367)
+- [Deep Dive into CKB-VM Memory Model: Design of W^X](https://talk.nervos.org/t/deep-dive-into-ckb-vm-memory-model-design-of-w-x/10398)
+- [Deep Dive into CKB-VM Assembly Executor](https://talk.nervos.org/t/deep-dive-into-ckb-vm-assembly-executor/10441)
+- [Deep Dive Into CKB-VM Macro-ops Fusion](https://talk.nervos.org/t/deep-dive-into-ckb-vm-macro-ops-fusion/10468)
+
+---
+
+_This article is adapted from [Deep Dive Into CKB-VM Macro-ops Fusion](https://talk.nervos.org/t/deep-dive-into-ckb-vm-macro-ops-fusion/10468) by [mohanson](https://talk.nervos.org/u/mohanson) on Nervos Talk._

--- a/website/docs/ckb-fundamentals/ckb-vm-internals/memory-model-wx.mdx
+++ b/website/docs/ckb-fundamentals/ckb-vm-internals/memory-model-wx.mdx
@@ -1,0 +1,260 @@
+---
+title: CKB-VM Memory Model — Design of W^X
+---
+
+In the previous article, we explored CKB-VM [snapshots v1](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366) and [snapshots v2](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v2-evolution/10367). One of the core tasks of snapshotting is marking and saving “dirty pages.” That article repeatedly mentioned page flag markers: `FLAG_DIRTY`, `FLAG_EXECUTABLE`, `FLAG_WRITABLE` but never explained where these flags come from, or the more fundamental design behind them: the W^X memory model.
+
+This article fills that gap. We start from the lowest-level evolution of CKB-VM’s memory subsystem, move through the bit-level design of W^X, and then examine how it interacts with ELF loading and the snapshot system.
+
+## Why the Memory Model Matters
+
+From a security perspective, smart contracts on a blockchain run in an extremely hostile environment. Contract code comes from anonymous users; nodes must execute it without any prior trust, and execution results must be reproducible and verifiable. A few attack surfaces worth noting:
+
+- Writing malicious instructions into the code segment, then jumping to them (code injection)
+- Chaining existing code gadgets into malicious logic (ROP/JOP)
+- Overwriting return addresses via crafted stack layouts to bypass permission checks
+
+For the first two categories, modern operating systems and browsers long ago converged on a standard answer: [W^X](https://en.wikipedia.org/wiki/W%5EX) (Write XOR Execute), any given memory page is, at any given moment, either writable or executable, **but never both**. This principle was first introduced by OpenBSD in 2003 and subsequently adopted by nearly every major platform: Windows (DEP), Linux (PaX/NX), macOS, and others.
+
+For an on-chain virtual machine like CKB-VM, W^X is essentially mandatory. Without it, any buffer overflow could be directly weaponized into remote code execution.
+
+> CKB-VM also has a CFI extension instruction set designed to mitigate ROP/JOP attacks; it is still under development. See [this pull request](https://github.com/nervosnetwork/ckb-vm/pull/492) for details.
+
+## The Simplest Starting Point: FlatMemory
+
+When you don’t need to worry about permissions or memory efficiency, the most intuitive memory implementation is a large array. From its earliest days, CKB-VM had an implementation called `FlatMemory` that used a single 4 MB `Vec<u8>` to simulate the entire linear address space. Its advantage is simplicity, no complex data structures or algorithms. Its disadvantage is wastefulness, since most scripts use far less than 4 MB in practice.
+
+```rust
+pub struct FlatMemory<R> {
+    data: Vec<u8>,        // The full 4 MB byte array
+    flags: Vec<u8>,       // One flag byte per page
+    memory_size: usize,   // Total size, default 4 MB
+    // ...
+}
+```
+
+`FlatMemory` allocates the entire 4 MB at construction time via `vec![0; memory_size]`. It provides the most basic read/write interface, write operations automatically set `FLAG_DIRTY`, but performs no permission checks whatsoever. Its purpose is to serve as a correct, simple reference backend for interpreter mode and as a baseline for comparison with more complex implementations.
+
+> In early versions of CKB-VM, interpreter mode ran on FlatMemory. Later, to unify the permission model, all backends were switched to a `WXorXMemory` wrapping `SparseMemory` combination. Let’s continue reading.
+
+## From Flat to Sparse: On-Demand Allocation
+
+FlatMemory is simple, but it has one glaring inefficiency: most CKB scripts use far less than 4 MB. A typical signature-verification script might only need a few tens of kilobytes. FlatMemory allocates the full 4 MB at construction, meaning every script-execution thread on every CKB node consumes 4 MB of physical memory. When a node runs hundreds of scripts concurrently, memory pressure mounts quickly.
+
+`SparseMemory` solves exactly this problem:
+
+```rust
+pub struct SparseMemory<R> {
+    indices: Vec<u16>,    // Index table per page; unallocated pages use INVALID_PAGE_INDEX (0xFFFF)
+    pages: Vec<Page>,     // List of actually allocated pages
+    flags: Vec<u8>,       // Per-page flags, present regardless of whether the page is allocated
+    // ...
+}
+```
+
+The core idea is lazy allocation: at construction, only empty index and flags tables are created; no data pages are allocated. When the VM first accesses a page, `fetch_page` appends a new page to `pages` and records its index in `indices`.
+
+```rust
+fn fetch_page(&mut self, aligned_addr: u64) -> Result<&mut Page, Error> {
+    let page = aligned_addr / RISCV_PAGESIZE as u64;
+    let mut index = self.indices[page as usize];
+    if index == INVALID_PAGE_INDEX {
+        self.pages.push([0; RISCV_PAGESIZE]);
+        index = (self.pages.len() - 1) as u16;
+        self.indices[page as usize] = index;
+    }
+    Ok(&mut self.pages[index as usize])
+}
+```
+
+The overhead of this design is the `indices` table: 2 bytes (u16) per page, totaling about 2 KB for a 4 MB address space (1024 pages). Given the physical memory it saves, that overhead is negligible.
+
+One noteworthy point: the `flags` table in `SparseMemory` is still fully allocated regardless of whether any given page has been allocated. This is intentional: permission checks happen before memory access. If the flags table were also lazily allocated, it would introduce a chicken-and-egg circular dependency between permission checking and page allocation.
+
+> `SparseMemory` also contains no permission-check logic. Like `FlatMemory`, it is solely responsible for data storage; permissions are delegated to the wrapping `WXorXMemory`. This separation of concerns is the most fundamental design principle of CKB-VM’s memory subsystem.
+
+## Enter W^X: WXorXMemory
+
+Now we arrive at the protagonist of this article. `WXorXMemory` is a generic wrapper that wraps any `Memory` implementation (in practice, always `SparseMemory`) and inserts W^X permission checks on its read and write paths.
+
+```rust
+pub struct WXorXMemory<M: Memory> {
+    inner: M,
+}
+```
+
+This is the classic “decorator pattern” in Rust. Most methods (such as `load8`, `load16`, `fetch_flag`) are forwarded directly to `inner`; only write operations and instruction fetch operations are intercepted , they perform a permission check before forwarding.
+
+```rust
+fn store8(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
+    check_no_overflow(addr.to_u64(), 1, self.memory_size() as u64)?;
+    let page_indices = get_page_indices(addr.to_u64(), 1);
+    check_permission(self, &page_indices, FLAG_WRITABLE)?;  // <-- W^X check
+    self.inner.store8(addr, value)
+}
+
+fn execute_load16(&mut self, addr: u64) -> Result<u16, Error> {
+    check_no_overflow(addr, 2, self.memory_size() as u64)?;
+    let page_indices = get_page_indices(addr, 2);
+    check_permission(self, &page_indices, FLAG_EXECUTABLE)?; // <-- W^X check
+    self.inner.execute_load16(addr)
+}
+```
+
+Note that `execute_load16` and `execute_load32` are **separate methods, distinct from regular loads**. The regular loads (`load8`/`load16`/`load32`/`load64`) serve data-access instructions like `lb`/`lw` and do not check `FLAG_EXECUTABLE`. `execute_load16` and `execute_load32` are dedicated to instruction fetch, reading the 16-bit or 32-bit encoding of (compressed) instructions. **Instruction fetches go through the executable check; data accesses go through the writable check. The two are mutually exclusive and complementary.**
+
+Now we come to what I consider the most elegant part of the entire implementation. Opening the source, the four flag constants are defined as follows:
+
+```rust
+pub const FLAG_FREEZED:    u8 = 0b01;
+pub const FLAG_EXECUTABLE: u8 = 0b10;
+pub const FLAG_WXORX_BIT:  u8 = 0b10;  // Same value as FLAG_EXECUTABLE
+pub const FLAG_WRITABLE:   u8 = (!FLAG_EXECUTABLE) & FLAG_WXORX_BIT;
+pub const FLAG_DIRTY:      u8 = 0b100;
+```
+
+Look at the value of `FLAG_WRITABLE`. `!FLAG_EXECUTABLE` inverts all bits; in an 8-bit space that gives `0b11111101`. AND-ing with `FLAG_WXORX_BIT` (0b10) yields `0b00000000` , that is, 0.
+
+This means **FLAG_WRITABLE equals 0**. A page is “writable” when bit 1 is 0; it is “executable” when bit 1 is 1. A single bit, with its two possible values, exactly encodes the mutually exclusive W and X states.
+
+With this design, the W^X check becomes extremely concise:
+
+```rust
+pub fn check_permission<M: Memory>(
+    memory: &mut M,
+    page_indices: &(u64, u64),
+    flag: u8,
+) -> Result<(), Error> {
+    for page in page_indices.0..=page_indices.1 {
+        let page_flag = memory.fetch_flag(page)?;
+        if (page_flag & FLAG_WXORX_BIT) != (flag & FLAG_WXORX_BIT) {
+            return Err(Error::MemWriteOnExecutablePage(page));
+        }
+    }
+    Ok(())
+}
+```
+
+Let’s walk through the three scenarios:
+
+| Operation         | `flag` argument          | `flag & 0b10` | Page writable (bit1=0) | Page executable (bit1=1) |
+| ----------------- | ------------------------ | ------------- | ---------------------- | ------------------------ |
+| Write             | `FLAG_WRITABLE` (0)      | `0`           | `0 == 0` → allow       | `0b10 != 0` → deny       |
+| Instruction fetch | `FLAG_EXECUTABLE` (0b10) | `0b10`        | `0 != 0b10` → deny     | `0b10 == 0b10` → allow   |
+
+No two independent check paths are needed; no if-else branch to distinguish “is this a write or an execute?” , a single bit comparison handles all four combinations. Encoding mutually exclusive states with one bit is common in hardware description languages but rare in software implementations. The trade-off is slightly reduced readability (you need to understand the logic behind the design), but once you do, it feels remarkably elegant.
+
+## Page Freezing: FLAG_FREEZED
+
+Beyond W^X, there is another important protection mechanism: `FLAG_FREEZED`. If bit 0 is set to 1, the page is frozen and cannot be modified afterward. Freezing happens inside `WXorXMemory::init_pages`:
+
+```rust
+fn init_pages(&mut self, addr: u64, size: u64, flags: u8, ...) -> Result<(), Error> {
+    for page_addr in (addr..addr + size).step_by(RISCV_PAGESIZE) {
+        let page = page_addr / RISCV_PAGESIZE as u64;
+        if self.fetch_flag(page)? & FLAG_FREEZED != 0 {
+            return Err(Error::MemWriteOnFreezedPage(page));
+        }
+        self.set_flag(page, flags)?;
+    }
+    self.inner.init_pages(addr, size, flags, source, offset_from_addr)
+}
+```
+
+Freezing complements W^X: W^X ensures a page cannot be simultaneously writable and executable, but it does not prevent a page from toggling between “write first, execute later.” Freezing closes this temporal loophole: code segments and read-only data segments are frozen during ELF loading, so any subsequent attempt to modify them triggers a `MemWriteOnFreezedPage` error.
+
+## ELF Loading: Where Flags Come From
+
+Every segment in a RISC-V ELF file has a `p_flags` field that encodes readability, writability, and executability via the `PF_R`, `PF_W`, and `PF_X` bits. The ELF loader translates these into CKB-VM page flags:
+
+```rust
+pub fn convert_flags(p_flags: u32, allow_freeze_writable: bool, vaddr: u64) -> Result<u8, Error> {
+    let readable = p_flags & PF_R != 0;
+    let writable = p_flags & PF_W != 0;
+    let executable = p_flags & PF_X != 0;
+    if !readable {
+        return Err(Error::ElfSegmentUnreadable(vaddr));
+    }
+    if writable && executable {
+        return Err(Error::ElfSegmentWritableAndExecutable(vaddr));
+    }
+    if executable {
+        Ok(FLAG_EXECUTABLE | FLAG_FREEZED)
+    } else if writable && !allow_freeze_writable {
+        Ok(0)
+    } else {
+        Ok(FLAG_FREEZED)
+    }
+}
+```
+
+The translation rules are:
+
+- **Unreadable segment** : rejected outright. In CKB-VM, non-readable memory does not exist.
+- **Segment with both`PF_W` and `PF_X`**: rejected outright. This violates W^X.
+- **Code segment (`PF_X`)**: gets `FLAG_EXECUTABLE | FLAG_FREEZED`. Frozen , cannot be modified.
+- **Data segment (`PF_W`)**: gets `0` (i.e., `FLAG_WRITABLE`). Not frozen , the script may modify it at runtime.
+- **Read-only data segment (neither`PF_X` nor `PF_W`)**: gets `FLAG_FREEZED`. Frozen to prevent runtime tampering.
+
+Note the path `writable && !allow_freeze_writable` returns `0`, meaning writable segments are **not frozen** in their initial state. If `allow_freeze_writable` is true (certain special scenarios), writable segments are also frozen, turning them into regions that are readable after initialization but no longer writable , similar to `.data.rel.ro`.
+
+When an ELF segment with `PF_W | PF_X` appears, CKB-VM refuses to load it. This cuts off the possibility of a W^X violation at the entry point itself.
+
+## Interaction with the Snapshot System
+
+Snapshots must preserve dirty pages and their flags, and restore them exactly. In Snapshot V1, the approach was to save the flag byte of each dirty page directly and write it back with `set_flag` during restoration. Snapshot V2 introduced the DataSource abstraction on top of that, but the logic for saving and restoring flags remained unchanged.
+
+W^X does not require special handling during snapshot restore, because page flags after restoration should be identical to their pre-suspend state. The only subtle point is that when `resume` restores dirty pages, it calls `memory_mut().store_bytes(...)`, and this path triggers `check_permission` in `WXorXMemory`. If a page had been executable before suspension, that store could fail due to W^X checks. In practice, however, snapshot restore happens after a fresh VM has just loaded ELF (at which point code pages are already correctly marked executable), and the dirty pages restored by V1 should all be data pages (marked writable), so no conflict occurs.
+
+## Performance of Memory Operations
+
+The performance overhead of W^X checks mainly comes from reading the page flag and performing bit comparisons before each memory access. Since flags are stored per page, each access needs to compute the page index, load the flag byte, and then do bitwise operations. Compared to the actual data read or write, this is an extra step. However, because flags are memory-resident, CPU caching significantly reduces the cost. Empirical tests show that the impact of W^X checks is acceptable and far smaller than the potential security risk.
+
+The x64 ASM backend in CKB-VM also optimizes W^X checks and significantly reduces hot-path overhead compared with the Rust interpreter implementation. If you only look at Rust code, W^X overhead can seem like an abstract `check_permission` call. In the x64 ASM backend, however, it is expanded into concrete instruction sequences. For example, in the `CHECK_WRITE` macro in [src/machine/asm/execute_x64.S](https://github.com/nervosnetwork/ckb-vm/blob/develop/src/machine/asm/execute_x64.S), write-memory instructions such as `sb/sh/sw/sd` all run through this logic first.
+
+Writes usually have spatial locality, meaning programs tend to write continuously within the same page. The x64 backend adds a small optimization for this pattern: it keeps a `last_write_page` register that records the page index of the previous write. When the next write occurs, it first compares the current page with `last_write_page`. If they are the same and the write does not cross a page boundary, it skips the full permission check. The complete check runs only on cross-page writes or on the first write to a page.
+
+1. Compute the current write page (`shr PAGE_SHIFTS`)
+2. Compare it with `last_write_page`
+3. Compute the end page of `addr + len` and confirm no page crossing
+4. If both checks hit, skip the full permission check
+
+This fast path is essentially a page-level cache: when writes stay within one page, most store instructions only add a few integer instructions and two branch checks, without repeatedly reading flags or repeatedly setting dirty bits.
+
+Now consider the slow path (cross-page write or first write to a page):
+
+1. Read `flags[page]`
+2. Execute `and WXORX_BIT` \+ `cmp WRITABLE`
+3. If mismatch, jump to `.exit_invalid_permission`
+4. If match, `or DIRTY` and write back the flag
+5. Check whether the corresponding frame is initialized, and call `inited_memory` when needed
+6. If cross-page, repeat the same process on the next page
+
+In other words, the true extra cost of W^X is concentrated at page transition points, not on every individual store instruction. In sequential same-page write scenarios, `last_write_page` amortizes the overhead significantly.
+
+Another important observation is that in the ASM execution loop, you do not see a per-instruction fetch-time check for `FLAG_EXECUTABLE`. `NEXT_INST` jumps directly within decoded traces, so the x64 backend pushes most executable-permission cost forward into the trace/decode stage, leaving primarily write-path W^X validation in runtime hot loops.
+
+Overall, W^X overhead at the x64 instruction level has two characteristics:
+
+- **Low amortized overhead** : for continuous writes within one page, extra cost is close to a constant-level branch overhead.
+- **Boundary sensitivity** : cross-page writes and first-touch writes trigger the full checking chain and cost noticeably more than the fast path.
+
+From the source code, we can see that memory-read and memory-write operations involve far more instructions than simple arithmetic operations (such as `add`, `sub`, and so on). To quantify memory-operation performance, Our benchmark shows even when the cycle counts are similar, actual runtime for continuous single-page memory writes is roughly 3x that of the `add` instruction, which is still acceptable in a VM context. But for cross-page writes, because the full W^X checking chain is triggered, performance can degrade to around 5x or more relative to `add`. Therefore, when writing CKB scripts, favor continuous memory access and avoid cross-page writes whenever possible to reduce W^X-related overhead.
+
+## Conclusion
+
+The core of the CKB-VM memory model consists of three parts: FlatMemory for correctness, SparseMemory for efficiency, and WXorXMemory for security. They are layered together, each with a clear responsibility.
+
+W^X itself is not a new technology; it has protected the operating systems and browsers we use every day for more than two decades. But in the context of a blockchain VM, it shifts from best practice to a hard survival baseline. Anyone can deploy code on-chain, and anyone can try to attack your contract. In such an adversarial environment, memory-model design cannot afford compromise.
+
+## Series of articles
+
+- [Deep Dive into CKB-VM Snapshot V1: Architecture and Design Principles](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366)
+- [Deep Dive into CKB-VM Snapshot V2: Evolution](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v2-evolution/10367)
+- [Deep Dive into CKB-VM Memory Model: Design of W^X](https://talk.nervos.org/t/deep-dive-into-ckb-vm-memory-model-design-of-w-x/10398)
+- [Deep Dive into CKB-VM Assembly Executor](https://talk.nervos.org/t/deep-dive-into-ckb-vm-assembly-executor/10441)
+- [Deep Dive Into CKB-VM Macro-ops Fusion](https://talk.nervos.org/t/deep-dive-into-ckb-vm-macro-ops-fusion/10468)
+
+---
+
+_This article is adapted from [Deep Dive into CKB-VM Memory Model: Design of W^X](https://talk.nervos.org/t/deep-dive-into-ckb-vm-memory-model-design-of-w-x/10398) by [mohanson](https://talk.nervos.org/u/mohanson) on Nervos Talk._

--- a/website/docs/ckb-fundamentals/ckb-vm-internals/snapshot-v1.mdx
+++ b/website/docs/ckb-fundamentals/ckb-vm-internals/snapshot-v1.mdx
@@ -1,0 +1,147 @@
+---
+title: CKB-VM Snapshot V1 — Architecture and Design Principles
+---
+
+## Background
+
+After receiving a new transaction, a CKB node must execute its scripts to validate it. A script is a user-provided Turing-complete program, and the compute cost of one execution can vary a lot: a simple signature check may need only a few million cycles, while a complex zero-knowledge proof verification can consume billions of cycles. If a node uses the same thread to process all transactions without distinction, one “large script” can occupy that thread for a long time, preventing newly arrived blocks from being validated in time.
+
+To address this, CKB node mempool logic uses two execution queues: a normal-script queue and a large-script queue. A new transaction enters the normal queue first and is executed by multiple worker threads in parallel. Once a transaction accumulates more than a configured cycle threshold in the normal queue, the node removes it from that queue and moves it to the dedicated large-script queue to continue execution. The benefit is that threads in the normal queue are not monopolized by a few long-running tasks, so the node always keeps enough compute capacity to react to new blocks.
+
+The key that makes this mechanism work is that when a script is **moved** , it must carry over its full execution state at that exact moment and continue seamlessly in another queue. It must neither restart from scratch nor lose intermediate results. Snapshot exists for this purpose: when a VM is about to reach the cycle limit of the current queue, it serializes the full execution state; later, in the large-script queue, the VM is restored from that snapshot under a new budget and continues unfinished work. This process is transparent to the script: the script does not need to know it was suspended and resumed.
+
+This article introduces Snapshot V1 in CKB-VM. The source code is in [src/snapshot.rs](https://github.com/nervosnetwork/ckb-vm/blob/develop/src/snapshot.rs).
+
+## What State Must Be Saved
+
+The execution state of a RISC-V VM can be divided into three parts: registers, program counter, and memory.
+
+Registers and PC are small and can be fully saved. Memory is the real trade-off. CKB-VM provides 4 MB of linear memory by default. If every snapshot serializes the whole memory as-is, it wastes both space and time. In practice, a script usually writes only a small fraction of memory during execution, so we only need to save these “dirty pages.”
+
+CKB-VM memory is managed in page granularity, 4 KB per page. Every page has one flag byte, and the `FLAG_DIRTY` bit marks whether the page has been written. The memory subsystem sets this flag automatically on every write. After `machine.load_elf` finishes loading the ELF, CKB-VM clears all dirty flags. Therefore, dirty pages observed during script execution correspond exactly to pages modified by the program, which are the pages snapshots must save.
+
+## Data Structure
+
+`Snapshot` is a serializable struct, defined as follows:
+
+```rust
+#[derive(Default, Deserialize, Serialize)]
+pub struct Snapshot {
+    pub version: u32,
+    pub registers: [u64; RISCV_GENERAL_REGISTER_NUMBER],
+    pub pc: u64,
+    pub page_indices: Vec<u64>,
+    pub page_flags: Vec<u8>,
+    pub pages: Vec<Vec<u8>>,
+    pub load_reservation_address: u64,
+}
+```
+
+Field meanings:
+
+- `version`: VM version number, used for validation during resume.
+- `registers`: 32 general-purpose RISC-V registers.
+- `pc`: program counter.
+- `page_indices`: list of dirty page indices.
+- `page_flags`: page flags corresponding one-to-one with `page_indices`.
+- `pages`: page contents corresponding one-to-one with `page_indices`, each page is 4 KB.
+- `load_reservation_address`: reservation address used by the A extension.
+
+The three `Vec` fields store dirty-page information as flattened arrays, instead of `Vec<(u64, u8, Vec<u8>)>`. This yields a more compact layout after serde serialization.
+
+## Creating a Snapshot
+
+The `make_snapshot` function builds a snapshot from a running VM. The core logic has two steps: copy registers and PC first, then iterate memory pages and extract dirty pages.
+
+```rust
+pub fn make_snapshot<T: CoreMachine>(machine: &mut T) -> Result<Snapshot, Error> {
+    let mut snap = Snapshot {
+        version: machine.version(),
+        pc: machine.pc().to_u64(),
+        load_reservation_address: machine.memory().lr().to_u64(),
+        ..Default::default()
+    };
+    for (i, v) in machine.registers().iter().enumerate() {
+        snap.registers[i] = v.to_u64();
+    }
+
+    for i in 0..machine.memory().memory_pages() {
+        let flag = machine.memory_mut().fetch_flag(i as u64)?;
+        if flag & FLAG_DIRTY != 0 {
+            let addr_from = i << RISCV_PAGE_SHIFTS;
+            let addr_to = (i + 1) << RISCV_PAGE_SHIFTS;
+            let mut page = vec![0; RISCV_PAGESIZE];
+            for i in (addr_from..addr_to).step_by(8) {
+                let v64 = machine
+                    .memory_mut()
+                    .load64(&T::REG::from_u64(i as u64))?
+                    .to_u64();
+                // ... split bytes and write into page
+            }
+            snap.page_indices.push(i as u64);
+            snap.page_flags.push(flag);
+            snap.pages.push(page);
+        }
+    }
+    Ok(snap)
+}
+```
+
+Two details are worth attention:
+
+First, memory traversal does not use direct `memcpy`; it calls `load64` with an 8-byte stride. This is because the `CoreMachine` trait abstracts different backends (pure Rust interpreter, ASM backend, AOT backend, etc.), and their internal memory layouts are different. The only universal read interface is the `load*` methods. Reading via `load64` and then splitting into 8 bytes guarantees snapshot logic works consistently across backends.
+
+Second, this code only checks the `FLAG_DIRTY` bit but saves the entire flag byte. This allows resume to restore other page attributes as well (such as executable, writable, etc.).
+
+## Resuming from a Snapshot
+
+The `resume` function loads a snapshot into a new VM. Callers typically `load_elf` again with the same ELF first. At that point, all static pages are in place and dirty flags are cleared. Then `resume` applies dirty-page patches on top of that base state to reconstruct a state equivalent to the suspended VM.
+
+```rust
+pub fn resume<T: CoreMachine>(machine: &mut T, snapshot: &Snapshot) -> Result<(), Error> {
+    if machine.version() != snapshot.version {
+        return Err(Error::InvalidVersion);
+    }
+    for (i, v) in snapshot.registers.iter().enumerate() {
+        machine.set_register(i, T::REG::from_u64(*v));
+    }
+    machine.update_pc(T::REG::from_u64(snapshot.pc));
+    machine.commit_pc();
+    for i in 0..snapshot.page_indices.len() {
+        let page_index = snapshot.page_indices[i];
+        let page_flag = snapshot.page_flags[i];
+        let page = &snapshot.pages[i];
+        let addr_from = page_index << RISCV_PAGE_SHIFTS;
+        machine.memory_mut().store_bytes(addr_from, &page[..])?;
+        machine.memory_mut().set_flag(page_index, page_flag)?;
+    }
+    machine
+        .memory_mut()
+        .set_lr(&T::REG::from_u64(snapshot.load_reservation_address));
+    Ok(())
+}
+```
+
+The first step is version validation: if the snapshot comes from a VM of a different version, it immediately returns `InvalidVersion`. Different hard-fork versions of CKB-VM can differ in instruction decoding and execution semantics, and cross-version resume may introduce subtle semantic errors. Rejecting is safer.
+
+Then registers, PC, and dirty pages are restored in sequence. `update_pc` \+ `commit_pc` is the standard PC update pattern in CKB-VM: `update_pc` writes the next instruction address, and `commit_pc` promotes it to current PC. This design matches the interpreter loop model of “fetch first, then commit.”
+
+## Limitations
+
+Snapshot V1 is simple and direct, but it has an obvious weakness: its definition of “dirty pages” is coarse. Any page that has been written is saved in full, even if most bytes were copied from read-only segments or transaction witness data that already exists elsewhere on-chain.
+
+For data-heavy scenarios (for example, scripts loading a full witness into memory via syscall), V1 snapshots can become very large. This is why CKB-VM later introduced Snapshot V2.
+
+The details of V2 are covered in the next article. Even after V2 appeared, V1 remains as the most basic and self-contained snapshot format, suitable for scenarios that do not depend on external data sources.
+
+## Series of articles
+
+- [Deep Dive into CKB-VM Snapshot V1: Architecture and Design Principles](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366)
+- [Deep Dive into CKB-VM Snapshot V2: Evolution](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v2-evolution/10367)
+- [Deep Dive into CKB-VM Memory Model: Design of W^X](https://talk.nervos.org/t/deep-dive-into-ckb-vm-memory-model-design-of-w-x/10398)
+- [Deep Dive into CKB-VM Assembly Executor](https://talk.nervos.org/t/deep-dive-into-ckb-vm-assembly-executor/10441)
+- [Deep Dive Into CKB-VM Macro-ops Fusion](https://talk.nervos.org/t/deep-dive-into-ckb-vm-macro-ops-fusion/10468)
+
+---
+
+_This article is adapted from [Deep Dive into CKB-VM Snapshot V1: Architecture and Design Principles](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366) by [mohanson](https://talk.nervos.org/u/mohanson) on Nervos Talk._

--- a/website/docs/ckb-fundamentals/ckb-vm-internals/snapshot-v2.mdx
+++ b/website/docs/ckb-fundamentals/ckb-vm-internals/snapshot-v2.mdx
@@ -1,0 +1,210 @@
+---
+title: CKB-VM Snapshot V2 — Evolution
+---
+
+## Background
+
+In [Deep Dive into CKB-VM Snapshot V1: Architecture and Design Principles](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366), we introduced the earliest snapshot approach in CKB-VM: copy every dirty page in full and serialize it together with registers and PC. This approach is correct and simple, but in real workloads it reveals a clear weakness: snapshot size can be much larger than “data actually modified by the script.”
+
+A typical class of examples is syscall-driven loading of transaction-originated data into script memory. When a script calls `ckb_load_witness`, witness bytes are copied into a target buffer; when it calls `ckb_load_cell_data`, cell bytes (sometimes from large dep cells) may cover dozens of pages; and when it reads structured transaction fields (input/output lock, type, capacity, header, script hash, out point), many small metadata slices are repeatedly copied via syscalls. At the memory layer, all of these copies look like page writes and are marked dirty, so V1 serializes them as if they were script-produced modifications. Semantically, however, these bytes are byte-for-byte transfers from already available on-chain transaction data, so saving them again in snapshots is redundant and can significantly inflate snapshot size.
+
+There is also another important scenario: the program image itself. During ELF loading, code segments and read-only data segments are written into VM memory, which still appears as ordinary page writes to the memory subsystem. But these bytes come from a fixed, immutable ELF input rather than from runtime computation by the script. If snapshots persist them page by page again, they effectively package the program one more time, which becomes a noticeable overhead for larger binaries.
+
+Therefore, the problem Snapshot V2 solves can be stated more generally: whenever a memory region is populated by byte-for-byte transfer from a stable external object, rather than newly computed by script execution, it should not be treated as dirty pages by default. Witness is only the easiest example to observe; cell data, transaction metadata, and ELF program segments are all the same class of problem.
+
+Snapshot V2 is designed for exactly this type of scenario. Its core idea is to introduce a “data source” abstraction: pages whose content comes entirely from external data that can be deterministically retrieved again are stored as references (`id + offset + length`) instead of full page bytes. Pages truly produced or modified by script computation are still saved page-by-page like V1.
+
+This article introduces Snapshot V2. The source code is in [src/snapshot2.rs](https://github.com/nervosnetwork/ckb-vm/blob/develop/src/snapshot2.rs).
+
+## DataSource Abstraction
+
+V2 uses a trait to describe a data source that is addressable and stable during VM lifetime:
+
+```rust
+pub trait DataSource<I: Clone + PartialEq> {
+    fn load_data(&self, id: &I, offset: u64, length: u64) -> Option<(Bytes, u64)>;
+}
+```
+
+- `I` is the identifier type of data entries, defined by the integrator. In CKB, it is usually an enum used to distinguish cell data, witness, and other sources, while carrying their indices.
+- `load_data` takes `id`, `offset`, and requested `length`, and returns both the actual bytes read and the “full remaining length from offset.” This mirrors CKB syscall behavior, allowing the caller to tell scripts how many bytes are actually available even when only a slice is read this time.
+
+DataSource has an implicit contract: within a VM lifetime, the same `(id, offset, length)` must always return the same bytes. Otherwise, the resumed VM would not be equivalent to the suspended VM. Using transaction data as a source naturally satisfies this contract because transactions are immutable.
+
+## Snapshot2Context
+
+V2 is no longer a stateless set of functions. It introduces a stateful context object, `Snapshot2Context`, that lives alongside VM execution:
+
+```rust
+pub struct Snapshot2Context<I: Clone + PartialEq, D: DataSource<I>> {
+    // page index -> (id, offset, flag)
+    pages: HashMap<u64, (I, u64, u8)>,
+    data_source: D,
+}
+```
+
+This `pages` map is the core data structure of V2. It records each page whose content comes entirely from a data source, including the source id, source offset, and page flag. Entries correspond one-to-one with real memory pages, but page bytes are not stored in the map; bytes can be retrieved on demand via `data_source.load_data`.
+
+As long as this map stays accurate, snapshot creation can replace these pages with data-source references, and snapshot size drops naturally.
+
+## Tracking and Untracking
+
+`Snapshot2Context` maintains the `pages` map through two inverse operations:
+
+```rust
+pub fn track_pages<M>(&mut self, machine: &mut M,
+    start: u64, mut length: u64, id: &I, mut offset: u64) -> Result<(), Error>;
+
+pub fn untrack_pages<M>(&mut self, machine: &mut M,
+    start: u64, length: u64) -> Result<(), Error>;
+```
+
+`track_pages` records fully covered pages in `[start, start+length)` as “coming from source `id` starting at `offset`.” Several details matter:
+
+- It aligns `start` upward to a page boundary and drops head/tail fragments that do not cover full pages. The reason is that partial pages can contain a mix of source bytes and other content, and therefore cannot be represented by a single source reference.
+- Before recording, it explicitly calls `clear_flag(page, FLAG_DIRTY)`. Although those bytes may have just been written via `store_bytes`, semantically they are still “loaded from source as-is” and should not be treated as dirty pages, otherwise snapshot creation would redundantly save them again as V1-style dirty data.
+- The stored flag is the current page flag read back after clearing DIRTY, so resume can restore other bits as well (read/write/execute, etc.).
+
+`untrack_pages` performs the opposite operation. When a memory range is about to be written by script logic, all overlapping pages are first removed from `pages`, and DIRTY is set again. This prevents misclassifying pages as clean source pages after partial overwrites. Once overwritten, such a page no longer equals source content.
+
+## Two Integration Entry Points
+
+Track/untrack alone is not enough. They must be inserted into all operations that move data-source bytes into memory. V2 provides two high-level entry points.
+
+The first is `store_bytes`, which replaces direct `Memory::store_bytes` for syscalls that write external data into script memory:
+
+```rust
+pub fn store_bytes<M>(&mut self, machine: &mut M,
+    addr: u64, id: &I, offset: u64, length: u64, size_addr: u64
+) -> Result<(u64, u64), Error> {
+    let (data, full_length) = self.load_data(id, offset, length)?;
+    machine.memory_mut().store64(
+        &M::REG::from_u64(size_addr), &M::REG::from_u64(full_length))?;
+    self.untrack_pages(machine, addr, data.len() as u64)?;
+    machine.memory_mut().store_bytes(addr, &data)?;
+    self.track_pages(machine, addr, data.len() as u64, id, offset)?;
+    Ok((data.len() as u64, full_length))
+}
+```
+
+Its execution order is: load data → write “full length” to `size_addr` (matching CKB syscall convention) → untrack target range (clear any existing references) → write bytes → track again with new references. All syscall-style loading paths (load witness, load cell data, etc.) should enter memory through this method to benefit from V2 size optimization.
+
+The second entry point is `mark_program`, used to register the ELF program itself. CKB-VM’s current `load_program` is not on the `SupportMachine` trait and is not easy to intercept directly, so V2 uses a two-step workflow:
+
+```rust
+pub fn mark_program<M>(&mut self, machine: &mut M,
+    metadata: &ProgramMetadata, id: &I, offset: u64) -> Result<(), Error> {
+    for action in &metadata.actions {
+        self.init_pages(machine, action, id, offset)?;
+    }
+    Ok(())
+}
+```
+
+The caller first gets `ProgramMetadata` from `elf::parse_elf`, then loads the program using `load_program_with_metadata`, and finally passes metadata to `mark_program`. Each `LoadingAction` in metadata describes how one ELF segment is loaded: destination address, length, and source range in the file. `init_pages` converts this to `(memory address, source offset, length)` and calls `track_pages`. This makes code segments and read-only data segments also represented as data-source references, further reducing snapshot size.
+
+## Creating a Snapshot
+
+`make_snapshot` serializes current VM state into `Snapshot2`:
+
+```rust
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Snapshot2<I: Clone + PartialEq> {
+    // (address, flag, id, source offset, source length)
+    pub pages_from_source: Vec<(u64, u8, I, u64, u64)>,
+    // (address, flag, content)
+    pub dirty_pages: Vec<(u64, u8, Vec<u8>)>,
+    pub version: u32,
+    pub registers: [u64; RISCV_GENERAL_REGISTER_NUMBER],
+    pub pc: u64,
+    pub cycles: u64,
+    pub max_cycles: u64,
+    pub load_reservation_address: u64,
+}
+```
+
+Compared with V1, this adds three categories: `pages_from_source` for source references, `cycles` and `max_cycles` for restoring VM metering state (V1 does not store these and leaves management to callers). Other fields keep the same meaning.
+
+Snapshot creation runs in two passes:
+
+```rust
+pub fn make_snapshot<M>(&self, machine: &mut M) -> Result<Snapshot2<I>, Error> {
+    let mut dirty_pages: Vec<(u64, u8, Vec<u8>)> = vec![];
+    for i in 0..machine.memory().memory_pages() as u64 {
+        let flag = machine.memory_mut().fetch_flag(i)?;
+        if flag & FLAG_DIRTY == 0 { continue; }
+        let address = i * PAGE_SIZE;
+        let mut data: Vec<u8> = machine.memory_mut().load_bytes(address, PAGE_SIZE)?.into();
+        if let Some(last) = dirty_pages.last_mut() {
+            if last.0 + last.2.len() as u64 == address && last.1 == flag {
+                last.2.append(&mut data);
+            }
+        }
+        if !data.is_empty() {
+            dirty_pages.push((address, flag, data));
+        }
+    }
+    // ... second pass: scan self.pages to build pages_from_source
+}
+```
+
+The first pass collects dirty pages like V1, but with merging: if the current record is contiguous with the previous one and has the same flag, they are merged. This “merge contiguous ranges” optimization is even more important when generating `pages_from_source`. In the second pass over `self.pages`, pages are merged only when all four conditions hold: contiguous addresses, same flag, same `id`, and contiguous source offsets. This can compress multi-page references to one witness range into a single record, further reducing snapshot size.
+
+`make_snapshot` also performs a small but important conflict resolution: if a page appears in both `self.pages` and the dirty list, dirty wins and the corresponding `pages_from_source` entry is skipped. This covers boundary cases like “loaded via `store_bytes`, then partially overwritten later without a proper `untrack_pages` path,” and dirty-first guarantees correctness after resume.
+
+## Resuming a Snapshot
+
+`resume` is the inverse of `make_snapshot`:
+
+```rust
+pub fn resume<M>(&mut self, machine: &mut M, snapshot: &Snapshot2<I>) -> Result<(), Error> {
+    if machine.version() != snapshot.version { return Err(Error::InvalidVersion); }
+    self.pages.clear();
+    // restore registers, PC, cycles, max_cycles ...
+    for (address, flag, id, offset, length) in &snapshot.pages_from_source {
+        let (data, _) = self.load_data(id, *offset, *length)?;
+        machine.memory_mut().store_bytes(*address, &data)?;
+        for i in 0..(data.len() as u64 / PAGE_SIZE) {
+            machine.memory_mut().set_flag(address / PAGE_SIZE + i, *flag)?;
+        }
+        self.track_pages(machine, *address, data.len() as u64, id, *offset)?;
+    }
+    for (address, flag, content) in &snapshot.dirty_pages {
+        machine.memory_mut().store_bytes(*address, content)?;
+        for i in 0..(content.len() as u64 / PAGE_SIZE) {
+            machine.memory_mut().set_flag(address / PAGE_SIZE + i, *flag)?;
+        }
+    }
+    machine.memory_mut()
+        .set_lr(&M::REG::from_u64(snapshot.load_reservation_address));
+    Ok(())
+}
+```
+
+The first step is still version validation. The second step clears `self.pages`, because resume enters a fresh context where old tracking info is meaningless. Then it restores registers, PC, cycles, and max_cycles.
+
+Next it processes `pages_from_source`: for each reference, it reloads bytes from the data source via `load_data`, writes them to memory, restores page flags via `set_flag`, and finally calls `track_pages` to rebuild tracking entries in `self.pages`. This is crucial: resumed state must be equivalent not only in memory/register contents but also in tracking semantics, so future `make_snapshot` calls still recognize source pages correctly. During this step, each reference is alignment-validated, and `MemPageUnalignedAccess` is returned immediately if address or length is not page-aligned.
+
+Finally it processes `dirty_pages`: content is written back in V1 style and flags are restored. These pages naturally carry DIRTY and do not need to be tracked in `self.pages`.
+
+## Comparison with V1
+
+V2 introduces three substantive extensions over V1:
+
+- It adds the DataSource abstraction, storing pages whose content comes from external data as references rather than full bytes. For scripts that load large external data through syscalls, snapshot size can drop by more than an order of magnitude.
+- It tracks the ELF program itself. Through `mark_program`, code and read-only segments are also represented as source references, shrinking snapshots further.
+- It includes `cycles` and `max_cycles` in snapshots. V1 only saves computational state and leaves metering to callers; V2 treats metering as VM state, making the resumed VM fully equivalent to the suspended VM and easier to use.
+
+The trade-off is that V2 makes page tracking part of all data-loading paths. Any syscall that moves external bytes into VM memory must use `Snapshot2Context::store_bytes` rather than `Memory::store_bytes`. Otherwise optimization is lost, and in some cases snapshot information may become incomplete. This difference is transparent to script authors, but syscall implementers must consistently route through `Snapshot2Context`.
+
+## Series of articles
+
+- [Deep Dive into CKB-VM Snapshot V1: Architecture and Design Principles](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v1-architecture-and-design-principles/10366)
+- [Deep Dive into CKB-VM Snapshot V2: Evolution](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v2-evolution/10367)
+- [Deep Dive into CKB-VM Memory Model: Design of W^X](https://talk.nervos.org/t/deep-dive-into-ckb-vm-memory-model-design-of-w-x/10398)
+- [Deep Dive into CKB-VM Assembly Executor](https://talk.nervos.org/t/deep-dive-into-ckb-vm-assembly-executor/10441)
+- [Deep Dive Into CKB-VM Macro-ops Fusion](https://talk.nervos.org/t/deep-dive-into-ckb-vm-macro-ops-fusion/10468)
+
+---
+
+_This article is adapted from [Deep Dive into CKB-VM Snapshot V2: Evolution](https://talk.nervos.org/t/deep-dive-into-ckb-vm-snapshot-v2-evolution/10367) by [mohanson](https://talk.nervos.org/u/mohanson) on Nervos Talk._

--- a/website/docs/ckb-fundamentals/ckb-vm.md
+++ b/website/docs/ckb-fundamentals/ckb-vm.md
@@ -21,6 +21,10 @@ Nervos CKB offers native SDKs in several mainstream programming languages, such 
 
 The CKB network has introduced various CKB-VM versions over time to enhance security, performance, resolve bugs, and support new RISC-V extensions. To check out all versions of the CKB-VM from previous hard fork events, please visit [VM Version History](/docs/script/vm-version)
 
+## CKB-VM Internals
+
+For a deeper look at the design and implementation of CKB-VM, see the [CKB-VM Internals](/docs/ckb-fundamentals/ckb-vm-internals/snapshot-v1) series, which covers snapshots, memory model, assembly executor, and macro-operation fusion.
+
 ---
 
 For more information on CKB-VM, please refer to the [RFC CKB-VM](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0003-ckb-vm/0003-ckb-vm.md).

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -309,6 +309,18 @@ export default {
         "ckb-fundamentals/ckb-vs-btc",
         "ckb-fundamentals/cell-model",
         "ckb-fundamentals/ckb-vm",
+        {
+          type: "category",
+          label: "CKB-VM Internals",
+          collapsible: true,
+          items: [
+            "ckb-fundamentals/ckb-vm-internals/snapshot-v1",
+            "ckb-fundamentals/ckb-vm-internals/snapshot-v2",
+            "ckb-fundamentals/ckb-vm-internals/memory-model-wx",
+            "ckb-fundamentals/ckb-vm-internals/assembly-executor",
+            "ckb-fundamentals/ckb-vm-internals/macro-ops-fusion",
+          ],
+        },
         "ckb-fundamentals/consensus",
         "ckb-fundamentals/ckb-address",
         "ckb-fundamentals/ckbhash",


### PR DESCRIPTION
This PR adds the five CKB-VM deep-dive articles by mohanson from Nervos Talk to the docs site, as requested.

### Changes

- Added a new **CKB-VM Internals** category under **CKB Fundamentals**.
- Added the following articles (adapted from Nervos Talk with attribution):
  - [CKB-VM Snapshot V1 — Architecture and Design Principles](/docs/ckb-fundamentals/ckb-vm-internals/snapshot-v1)
  - [CKB-VM Snapshot V2 — Evolution](/docs/ckb-fundamentals/ckb-vm-internals/snapshot-v2)
  - [CKB-VM Memory Model — Design of W^X](/docs/ckb-fundamentals/ckb-vm-internals/memory-model-wx)
  - [CKB-VM Assembly Executor](/docs/ckb-fundamentals/ckb-vm-internals/assembly-executor)
  - [CKB-VM Macro-ops Fusion](/docs/ckb-fundamentals/ckb-vm-internals/macro-ops-fusion)
- Updated  to include the new category.
- Added a cross-link from the [CKB-VM overview](/docs/ckb-fundamentals/ckb-vm) page.

### Notes

- The articles are placed after the existing CKB-VM overview page so readers can start with the high-level introduction and then dive into internals.
- Each article preserves the original Rust code blocks and includes an attribution link to the original Nervos Talk post.
- The site builds successfully with yarn run v1.22.19
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command..

🤖 Generated with [Claude Code](https://claude.com/claude-code)