### PR TITLE
feat: add umami analytics tracking

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,6 +19,19 @@ const config = {
   organizationName: "nervosnetwork",
   projectName: "docs-new",
   headTags: [
+    ...(enableGtag
+      ? [
+          {
+            tagName: "script",
+            attributes: {
+              defer: "true",
+              src: "https://umami.retric.uk/script.js",
+              "data-website-id": "f5709da4-2855-4563-9d49-b0cbbf1fb615",
+              "data-domains": "docs.nervos.org",
+            },
+          },
+        ]
+      : []),
     {
       tagName: "meta",
       attributes: {

--- a/website/src/components/AnalyticsTracking/utils.ts
+++ b/website/src/components/AnalyticsTracking/utils.ts
@@ -112,21 +112,21 @@ export function sendAnalyticsEvent(
   eventName: string,
   params: AnalyticsEventParams
 ): void {
-  if (
-    typeof window === "undefined" ||
-    typeof window.gtag !== "function" ||
-    isLocalAnalyticsHost()
-  ) {
+  if (typeof window === "undefined" || isLocalAnalyticsHost()) {
     return;
   }
 
-  window.gtag(
-    "event",
-    eventName,
-    Object.fromEntries(
-      Object.entries(params).filter(([, value]) => value !== undefined)
-    )
+  const eventParams = Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined)
   );
+
+  if (typeof window.gtag === "function") {
+    window.gtag("event", eventName, eventParams);
+  }
+
+  if (typeof window.umami?.track === "function") {
+    window.umami.track(eventName, eventParams);
+  }
 }
 
 export function getLlmsFileName(value: string): string | undefined {

--- a/website/src/global.d.ts
+++ b/website/src/global.d.ts
@@ -1,3 +1,6 @@
 declare interface Window {
   gtag?: (...args: any[]) => void;
+  umami?: {
+    track: (eventName: string, data?: Record<string, unknown>) => void;
+  };
 }


### PR DESCRIPTION
Adds Umami alongside GA4 to evaluate it as a potential analytics replacement.