### PR TITLE
Correct grammar in rewards.mdx

### DIFF
--- a/website/docs/mining/rewards.mdx
+++ b/website/docs/mining/rewards.mdx
@@ -47,7 +47,7 @@ The total amount of secondary issuance issued annually is fixed at 1.344 billion
 
 ## Proposal Reward and Commit Reward
 
-Proposal Reward and Commit Reward are both sourced from transaction fees. When a transaction enters the transaction pool, it subsequently enters the Proposal Zone, followed by the Commitment Zone (meaning the transaction is packaged into a block). This a two-step confirmation process comes from NC-Max, to eliminate the bottleneck of block propagation delay.
+Proposal Reward and Commit Reward are both sourced from transaction fees. When a transaction enters the transaction pool, it subsequently enters the Proposal Zone, followed by the Commitment Zone (meaning the transaction is packaged into a block). This two-step confirmation process comes from NC-Max, to eliminate the bottleneck of block propagation delay.
 
 Miners who mine block N will receive:
 


### PR DESCRIPTION
Fixed grammatical error in the explanation of Proposal Reward and Commit Reward.