### PR TITLE
fix: add redirects for legacy 404 paths from latest tracking report

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -276,6 +276,62 @@ const config = {
             to: "/docs/script/program-language-for-script",
           },
           {
+            // Class 3: UDT
+            from: "/docs/script-course/intro-to-script-3",
+            to: "/docs/script/rust/rust-example-sudt-script",
+          },
+          {
+            // Class 4: WebAssembly on CKB (no modern equivalent page)
+            from: "/docs/script-course/intro-to-script-4",
+            to: "/docs/script/program-language-for-script",
+          },
+          {
+            // Class 5: Debugging
+            from: "/docs/script-course/intro-to-script-5",
+            to: "/docs/script/debug-script",
+          },
+          {
+            // Class 6: Type ID
+            from: "/docs/script-course/intro-to-script-6",
+            to: "/docs/script/type-id",
+          },
+          {
+            // Class 7: Advanced Duktape Examples
+            from: "/docs/script-course/intro-to-script-7",
+            to: "/docs/script/js/js-vm",
+          },
+          {
+            // Class 8: Performant WASM (no modern equivalent page)
+            from: "/docs/script-course/intro-to-script-8",
+            to: "/docs/script/program-language-for-script",
+          },
+          {
+            // Class 9: Cycle Reductions in Duktape Script
+            from: "/docs/script-course/intro-to-script-9",
+            to: "/docs/script/vm-cycle-limits",
+          },
+          {
+            // Class 10: Language Choices
+            from: "/docs/script-course/intro-to-script-10",
+            to: "/docs/script/program-language-for-script",
+          },
+          {
+            from: "/docs/tech-explanation/ckb-vm",
+            to: "/docs/ckb-fundamentals/ckb-vm",
+          },
+          {
+            from: "/docs/tech-explanation/cell-model",
+            to: "/docs/ckb-fundamentals/cell-model",
+          },
+          {
+            from: "/docs/basics/faq/general",
+            to: "https://docs-old.nervos.org/docs/basics/faq/general",
+          },
+          {
+            from: ["/docs/reference/economics", "/docs/concepts/supply"],
+            to: "/docs/assets-token-standards/economics",
+          },
+          {
             from: "/docs/script/ckb-script-ipc",
             to: "/docs/script/ckb-ipc",
           },

--- a/website/static/basic-concepts/economics-of-ckb.html
+++ b/website/static/basic-concepts/economics-of-ckb.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="refresh"
+      content="0; url=/docs/assets-token-standards/economics"
+    />
+    <link rel="canonical" href="/docs/assets-token-standards/economics" />
+  </head>
+  <script>
+    window.location.href =
+      "/docs/assets-token-standards/economics" +
+      window.location.search +
+      window.location.hash;
+  </script>
+</html>


### PR DESCRIPTION
## Why

The latest umami 404 report lists paths that previous redirect rounds did not cover. Investigation summary:

| Reported path | Root cause |
| --- | --- |
| `/docs/script-course/intro-to-script-{4..10}` | The script-course series was removed in v2.39.0 (#804). #843 only redirected classes 1–2. |
| `/docs/tech-explanation/ckb-vm`, `/docs/tech-explanation/cell-model` | Legacy external links. #852 only covered the `/docs/basics/concepts/*` variants of these pages. |
| `/docs/basics/faq/general` | Legacy path; page still exists on docs-old.nervos.org. |
| `/docs/reference/economics`, `/docs/concepts/supply` | Legacy paths for what is now `/docs/assets-token-standards/economics`. |
| `/basic-concepts/economics-of-ckb.html` | URL from the pre-Docusaurus docs site. |
| `/docs/node/devnet-from-existing-data` | **Already fixed**: the page itself was added on 2026-07-13 (#857); the 404 hits predate its publication. No redirect needed. |

## Changes

- `@docusaurus/plugin-client-redirects`: add redirects for the remaining script-course classes 3–10 (each mapped to its closest modern page: debug → `debug-script`, type-id → `type-id`, duktape → `js/js-vm`, cycle reduction → `vm-cycle-limits`, UDT → `rust-example-sudt-script`, WASM/language classes → `program-language-for-script`), plus `tech-explanation/ckb-vm` → `ckb-fundamentals/ckb-vm`, `tech-explanation/cell-model` → `ckb-fundamentals/cell-model`, `basics/faq/general` → docs-old (same pattern as neuron/imtoken/tools), and `reference/economics` + `concepts/supply` → `assets-token-standards/economics`.
- `website/static/basic-concepts/economics-of-ckb.html`: static redirect page. The client-redirects plugin cannot cover this path: it would write `economics-of-ckb.html/index.html`, but Vercel does not resolve `.html`-suffixed requests to directory indexes (verified against the live site), so the file must exist at the exact path. Markup mirrors the plugin's own redirect pages (meta refresh + canonical + JS fallback).

## Verification

- `yarn build` succeeds; all 14 redirect files are generated with the expected targets.
- All redirect targets return 200 on the live site.
- Verified on the live site that every redirected `from` path currently returns 404.