### PR TITLE
chore: bump version to 2.49.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs.nervos.org",
-  "version": "2.48.0",
+  "version": "2.49.0",
   "description": "Official docs website for Nervos CKB",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump the website version from 2.48.0 to 2.49.0.

## Validation

- `yarn prettier --check package.json`
- `yarn build`