### PR TITLE
ci: automate documentation releases

### DIFF
--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -120,8 +120,26 @@ The generator first honors these optional labels:
 - `release:new-content`
 - `release:fix`
 - `release:other`
+- `release:skip`
 
 Without a release label, `feat:` and `docs:` PR titles become New
 Content, `fix:` and similar titles become Fixes, and everything else
-becomes Other. The production envelope PR targeting `master` is excluded
-from the notes.
+becomes Other.
+
+For reader-facing wording, add an optional section to the pull request
+body:
+
+```markdown
+## Release note
+
+Added a CKB debugging guide with common troubleshooting steps.
+```
+
+The generator uses this text in the Release. When the section is blank
+or absent, it falls back to the pull request title with a conventional
+commit prefix such as `docs:` or `fix:` removed.
+
+Add `release:skip` to dependency updates, CI changes, and other internal
+pull requests that should remain in the Full Changelog without appearing
+in a category. The generated version bump PR and the production PR
+targeting `master` are excluded automatically.

--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -1,0 +1,127 @@
+# Release Automation
+
+The `Release` GitHub Actions workflow performs the complete production
+release from GitHub. It keeps the repository's two pull request audit
+trail and always uses regular merge commits.
+
+## One-time setup
+
+### 1. Create and install a GitHub App
+
+Create an organization-owned GitHub App named `docs-release-bot` and
+grant it access only to this repository.
+
+Configure these repository permissions:
+
+| Permission      | Access                |
+| --------------- | --------------------- |
+| Actions         | Read-only             |
+| Checks          | Read-only             |
+| Commit statuses | Read-only             |
+| Contents        | Read and write        |
+| Pull requests   | Read and write        |
+| Metadata        | Read-only (automatic) |
+
+The App does not need webhook events. Install it on
+`nervosnetwork/docs.nervos.org`, then generate a private key.
+
+### 2. Configure Actions credentials
+
+In **Settings → Secrets and variables → Actions**, add:
+
+- Repository variable `RELEASE_APP_ID`: the numeric GitHub App ID.
+- Repository secret `RELEASE_APP_PRIVATE_KEY`: the complete PEM private
+  key generated for the App.
+
+The workflow requests only the permissions listed above when it creates
+an installation token. The token is scoped to this repository and is
+revoked when the job finishes.
+
+### 3. Configure the production ruleset
+
+Edit the `production` ruleset that targets `master`. Add the installed
+GitHub App to **Bypass list** and select **For pull requests only**.
+
+Keep the existing rules:
+
+- Require a pull request.
+- Allow regular merge only.
+- Block force pushes and deletion.
+
+The pull-request-only bypass lets the release App merge the production
+PR without a human approval, while preventing direct pushes to
+`master`. Both release PRs and merge commits remain in the audit log.
+
+## Running a release
+
+1. Open **Actions → Release**.
+2. Select **Run workflow** and keep the workflow branch set to
+   `develop`.
+3. Choose the version increment:
+   - `minor` (default): `2.49.0` → `2.50.0`
+   - `patch`: `2.49.0` → `2.49.1`
+   - `major`: `2.49.0` → `3.0.0`
+   - `custom`: use the exact value from `custom_version`
+4. Optionally enable `dry_run`.
+5. Select **Run workflow**.
+
+Dry runs validate the repository state and preview release notes without
+creating branches, pull requests, tags, or releases.
+
+## Automated sequence
+
+For a real release, the workflow:
+
+1. Locks the repository to one active release workflow.
+2. Confirms the latest GitHub Release matches the version on `master`.
+3. Confirms `develop` contains unreleased content and has not drifted.
+4. Creates `release/vX.Y.Z` and changes only
+   `website/package.json`.
+5. Installs dependencies, checks formatting, and builds the site.
+6. Creates and regular-merges the version PR into `develop`.
+7. Waits for the PR checks, the `develop` push build, and Vercel.
+8. Creates and regular-merges `develop` into `master`.
+9. Waits for the production build and Vercel deployment.
+10. Creates an exact lightweight tag on the verified merge commit.
+11. Generates categorized release notes and publishes the latest GitHub
+    Release.
+12. Verifies the tag target and published Release.
+
+The expected check names are `node-js` and `Vercel`. Update
+`scripts/release/release.mjs` if either integration is renamed.
+
+## Failure and recovery
+
+The workflow stops immediately when a build or deployment fails. It
+never proceeds to a later merge, tag, or Release after a failed check.
+
+Use **Re-run all jobs** on the same workflow run after fixing a
+transient failure. The workflow reuses an existing release branch or
+merged release PR and resumes from the first incomplete stage. A hidden
+run marker in the Release prevents a successful run from publishing
+twice when it is re-run.
+
+The workflow deliberately stops if `develop` or `master` changes during
+the release. This prevents unrelated, unvalidated commits from entering
+the release. Follow the error shown in the workflow summary; for a
+`develop` drift error, close the generated version PR, delete its release
+branch, and start a new release.
+
+## Release note categories
+
+Release notes always contain:
+
+- `New Content`
+- `Fixes`
+- `Other`
+
+The generator first honors these optional labels:
+
+- `release:new-content`
+- `release:fix`
+- `release:other`
+
+Without a release label, `feat:` and `docs:` PR titles become New
+Content, `fix:` and similar titles become Fixes, and everything else
+becomes Other. The production envelope PR targeting `master` is excluded
+from the notes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## Release note
+
+<!--
+Optional: write one reader-facing sentence for the next GitHub Release.
+Leave this section blank to use the pull request title instead.
+For internal changes that should not appear in the Release, add the
+`release:skip` label.
+-->

--- a/.github/workflows/release-automation-ci.yaml
+++ b/.github/workflows/release-automation-ci.yaml
@@ -1,0 +1,30 @@
+name: Release Automation
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/release.yaml
+      - .github/workflows/release-automation-ci.yaml
+      - scripts/release/**
+  push:
+    branches:
+      - develop
+    paths:
+      - .github/workflows/release.yaml
+      - .github/workflows/release-automation-ci.yaml
+      - scripts/release/**
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20.x
+          package-manager-cache: false
+      - run: node --check scripts/release/release.mjs
+      - run: node --test scripts/release/*.test.mjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,90 @@
+name: Release
+
+run-name: Release ${{ inputs.custom_version || inputs.bump_type }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: Version increment
+        required: true
+        default: minor
+        type: choice
+        options:
+          - minor
+          - patch
+          - major
+          - custom
+      custom_version:
+        description: Exact version when increment is custom (for example 3.0.0)
+        required: false
+        type: string
+      dry_run:
+        description: Validate and preview without changing GitHub
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: production-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Orchestrate release
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-actions: read
+          permission-checks: read
+          permission-contents: write
+          permission-pull-requests: write
+          permission-statuses: read
+
+      - name: Check out develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20.x
+          cache: yarn
+          cache-dependency-path: website/yarn.lock
+
+      - name: Configure release bot
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          app_user="${APP_SLUG}[bot]"
+          app_user_id="$(gh api "/users/${app_user}" --jq .id)"
+          git config user.name "${app_user}"
+          git config user.email \
+            "${app_user_id}+${app_user}@users.noreply.github.com"
+          gh auth setup-git
+
+      - name: Test release automation
+        run: node --test scripts/release/*.test.mjs
+
+      - name: Run release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_BUMP: ${{ inputs.bump_type }}
+          RELEASE_VERSION: ${{ inputs.custom_version }}
+          RELEASE_DRY_RUN: ${{ inputs.dry_run }}
+        run: node scripts/release/release.mjs

--- a/README.md
+++ b/README.md
@@ -36,21 +36,24 @@ If you run into an issue on our documentation website you can contact us on [Ner
 
 ### Release
 
-Production release should be on the master branch.
+Production releases are automated by the
+[`Release`](./.github/workflows/release.yaml) GitHub Actions workflow.
 
-Please follow the steps below:
+To publish a release:
 
-1. Create a new PR that bumps the version in the `package.json` under `/website`
-2. Merge the PR on `develop` branch
-3. Create a new PR from `develop` that targeting on the `master` branch
-4. Obtain at least one approval before merging the PR into `master` branch
-5. Merge the PR into `master` branch using **regular merge only**; squash merge and rebase merge are not allowed
-6. Create a new tag and release on github targeting on the master branch
-7. The release content should include description of changes following 3 sections:
-   - New Content
-   - Fixes
-   - Others
-8. Example release content: https://github.com/nervosnetwork/docs.nervos.org/releases/tag/v2.35.0 
+1. Open **Actions → Release → Run workflow** on GitHub.
+2. Keep the workflow branch set to `develop`.
+3. Select `minor`, `patch`, `major`, or `custom`.
+4. Optionally enable `dry_run`, then run the workflow.
+
+The workflow validates and builds the site, creates the version PR into
+`develop`, creates the production PR into `master`, waits for CI and
+Vercel at every stage, uses regular merge commits, and publishes the tag
+and GitHub Release.
+
+See [Release Automation](./.github/RELEASE_AUTOMATION.md) for one-time
+GitHub App and ruleset setup, the complete sequence, release note rules,
+and failure recovery.
 
 ### Develop
 

--- a/scripts/release/release-lib.mjs
+++ b/scripts/release/release-lib.mjs
@@ -62,6 +62,16 @@ function normalizedLabels(pullRequest) {
   );
 }
 
+export function shouldSkipPullRequest(pullRequest) {
+  const labels = normalizedLabels(pullRequest);
+  const title = String(pullRequest.title ?? "").trim();
+
+  return (
+    labels.includes("release:skip") ||
+    /^chore: bump version to \d+\.\d+\.\d+$/i.test(title)
+  );
+}
+
 export function classifyPullRequest(pullRequest) {
   const labels = normalizedLabels(pullRequest);
 
@@ -105,6 +115,33 @@ export function classifyPullRequest(pullRequest) {
   return "other";
 }
 
+export function releaseSummary(pullRequest) {
+  const body = String(pullRequest.body ?? "").replace(/\r\n?/g, "\n");
+  const header = /(?:^|\n)##[ \t]+Release note[ \t]*(?:\n|$)/i.exec(body);
+
+  if (header) {
+    const remainder = body.slice(header.index + header[0].length);
+    const nextSection = /\n##[ \t]+\S/.exec(remainder);
+    const section = (
+      nextSection ? remainder.slice(0, nextSection.index) : remainder
+    )
+      .replace(/<!--[\s\S]*?-->/g, "")
+      .trim()
+      .replace(/\s+/g, " ");
+
+    if (section && !/^(?:n\/a|none|-)$/i.test(section)) {
+      return section;
+    }
+  }
+
+  const title = String(pullRequest.title ?? "").trim();
+  const cleanedTitle = title.replace(
+    /^[a-z][a-z0-9-]*(?:\([^)]*\))?!?:\s*/i,
+    ""
+  );
+  return cleanedTitle || title;
+}
+
 function releaseLine(pullRequest) {
   const author =
     pullRequest.user?.login ??
@@ -112,7 +149,8 @@ function releaseLine(pullRequest) {
     pullRequest.author ??
     "unknown";
   const url = pullRequest.html_url ?? pullRequest.url;
-  return `* ${pullRequest.title} by @${author} in ${url}`;
+  const link = pullRequest.number ? `[#${pullRequest.number}](${url})` : url;
+  return `* ${releaseSummary(pullRequest)} (${link}) by @${author}`;
 }
 
 function section(title, pullRequests, emptyText) {
@@ -135,9 +173,11 @@ export function renderReleaseNotes({
     other: [],
   };
 
-  const sorted = [...pullRequests].sort((left, right) =>
-    String(left.merged_at ?? "").localeCompare(String(right.merged_at ?? ""))
-  );
+  const sorted = pullRequests
+    .filter((pullRequest) => !shouldSkipPullRequest(pullRequest))
+    .sort((left, right) =>
+      String(left.merged_at ?? "").localeCompare(String(right.merged_at ?? ""))
+    );
 
   for (const pullRequest of sorted) {
     categories[classifyPullRequest(pullRequest)].push(pullRequest);

--- a/scripts/release/release-lib.mjs
+++ b/scripts/release/release-lib.mjs
@@ -1,0 +1,220 @@
+const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+export function parseVersion(value) {
+  const normalized = String(value ?? "")
+    .trim()
+    .replace(/^v/, "");
+  const match = SEMVER_PATTERN.exec(normalized);
+
+  if (!match) {
+    throw new Error(`Invalid semantic version: ${value}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    value: normalized,
+  };
+}
+
+export function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+
+  return a.major - b.major || a.minor - b.minor || a.patch - b.patch;
+}
+
+export function resolveTargetVersion({
+  currentVersion,
+  bumpType,
+  customVersion,
+}) {
+  const current = parseVersion(currentVersion);
+  let target;
+
+  if (bumpType === "custom") {
+    target = parseVersion(customVersion);
+  } else if (bumpType === "major") {
+    target = parseVersion(`${current.major + 1}.0.0`);
+  } else if (bumpType === "minor") {
+    target = parseVersion(`${current.major}.${current.minor + 1}.0`);
+  } else if (bumpType === "patch") {
+    target = parseVersion(
+      `${current.major}.${current.minor}.${current.patch + 1}`
+    );
+  } else {
+    throw new Error(`Unsupported bump type: ${bumpType}`);
+  }
+
+  if (compareVersions(target.value, current.value) <= 0) {
+    throw new Error(
+      `Target version ${target.value} must be newer than ${current.value}`
+    );
+  }
+
+  return target.value;
+}
+
+function normalizedLabels(pullRequest) {
+  return (pullRequest.labels ?? []).map((label) =>
+    String(typeof label === "string" ? label : label.name).toLowerCase()
+  );
+}
+
+export function classifyPullRequest(pullRequest) {
+  const labels = normalizedLabels(pullRequest);
+
+  if (
+    labels.some((label) =>
+      [
+        "release:new-content",
+        "enhancement",
+        "feature",
+        "type: feature",
+      ].includes(label)
+    )
+  ) {
+    return "newContent";
+  }
+
+  if (
+    labels.some((label) =>
+      ["release:fix", "bug", "bugfix", "fix", "type: bug"].includes(label)
+    )
+  ) {
+    return "fixes";
+  }
+
+  if (labels.includes("release:other")) {
+    return "other";
+  }
+
+  const title = String(pullRequest.title ?? "").trim();
+
+  if (/^(feat|docs)(?:\([^)]*\))?:/i.test(title)) {
+    return "newContent";
+  }
+
+  if (
+    /^(fix|bugfix|hotfix|correct|repair)(?:\([^)]*\))?(?::|\s|-)/i.test(title)
+  ) {
+    return "fixes";
+  }
+
+  return "other";
+}
+
+function releaseLine(pullRequest) {
+  const author =
+    pullRequest.user?.login ??
+    pullRequest.author?.login ??
+    pullRequest.author ??
+    "unknown";
+  const url = pullRequest.html_url ?? pullRequest.url;
+  return `* ${pullRequest.title} by @${author} in ${url}`;
+}
+
+function section(title, pullRequests, emptyText) {
+  const lines =
+    pullRequests.length > 0
+      ? pullRequests.map(releaseLine).join("\n")
+      : `(${emptyText})`;
+  return `## ${title}\n\n${lines}`;
+}
+
+export function renderReleaseNotes({
+  pullRequests,
+  repository,
+  previousTag,
+  tag,
+}) {
+  const categories = {
+    newContent: [],
+    fixes: [],
+    other: [],
+  };
+
+  const sorted = [...pullRequests].sort((left, right) =>
+    String(left.merged_at ?? "").localeCompare(String(right.merged_at ?? ""))
+  );
+
+  for (const pullRequest of sorted) {
+    categories[classifyPullRequest(pullRequest)].push(pullRequest);
+  }
+
+  return [
+    section(
+      "New Content",
+      categories.newContent,
+      "No new content in this release"
+    ),
+    section("Fixes", categories.fixes, "No fixes in this release"),
+    section("Other", categories.other, "No other changes in this release"),
+    `**Full Changelog**: https://github.com/${repository}/compare/${previousTag}...${tag}`,
+  ].join("\n\n");
+}
+
+export function evaluateCommitValidation({
+  checkRuns,
+  statuses,
+  minimumNodeRuns,
+}) {
+  const nodeRuns = checkRuns.filter((run) => run.name === "node-js");
+  const vercel = statuses.find((status) => status.context === "Vercel");
+
+  const failedNodeRun = nodeRuns.find(
+    (run) =>
+      run.status === "completed" &&
+      !["success", "neutral", "skipped"].includes(run.conclusion)
+  );
+
+  if (failedNodeRun) {
+    return {
+      state: "failure",
+      message: `node-js concluded with ${failedNodeRun.conclusion}`,
+    };
+  }
+
+  if (vercel && ["error", "failure"].includes(vercel.state)) {
+    return {
+      state: "failure",
+      message: `Vercel concluded with ${vercel.state}`,
+    };
+  }
+
+  const enoughNodeRuns = nodeRuns.length >= minimumNodeRuns;
+  const nodeRunsPassed =
+    enoughNodeRuns &&
+    nodeRuns.every(
+      (run) =>
+        run.status === "completed" &&
+        ["success", "neutral", "skipped"].includes(run.conclusion)
+    );
+  const vercelPassed = vercel?.state === "success";
+
+  if (nodeRunsPassed && vercelPassed) {
+    return {
+      state: "success",
+      message: `${nodeRuns.length} node-js run(s) and Vercel passed`,
+    };
+  }
+
+  const pending = [];
+  if (!enoughNodeRuns) {
+    pending.push(`node-js checks ${nodeRuns.length}/${minimumNodeRuns}`);
+  } else if (!nodeRunsPassed) {
+    pending.push("node-js is still running");
+  }
+
+  if (!vercel) {
+    pending.push("Vercel status has not appeared");
+  } else if (!vercelPassed) {
+    pending.push(`Vercel is ${vercel.state}`);
+  }
+
+  return {
+    state: "pending",
+    message: pending.join("; "),
+  };
+}

--- a/scripts/release/release-lib.test.mjs
+++ b/scripts/release/release-lib.test.mjs
@@ -4,8 +4,10 @@ import test from "node:test";
 import {
   classifyPullRequest,
   evaluateCommitValidation,
+  releaseSummary,
   renderReleaseNotes,
   resolveTargetVersion,
+  shouldSkipPullRequest,
 } from "./release-lib.mjs";
 
 test("resolves semantic version bumps", () => {
@@ -72,6 +74,62 @@ test("classifies release notes from labels and conventional titles", () => {
   );
 });
 
+test("uses a reader-facing release note with a cleaned-title fallback", () => {
+  assert.equal(
+    releaseSummary({
+      title: "docs(guide): add a CKB debugging guide",
+      body: `## Summary
+
+Internal implementation details.
+
+## Release note
+
+<!-- Optional guidance is ignored. -->
+Added a CKB debugging guide with
+common troubleshooting steps.
+
+## Testing
+
+Built the website locally.`,
+    }),
+    "Added a CKB debugging guide with common troubleshooting steps."
+  );
+
+  assert.equal(
+    releaseSummary({
+      title: "docs(guide): add a CKB debugging guide",
+      body: `## Release note
+
+<!-- Leave blank to use the pull request title. -->`,
+    }),
+    "add a CKB debugging guide"
+  );
+});
+
+test("skips explicitly excluded and automated version pull requests", () => {
+  assert.equal(
+    shouldSkipPullRequest({
+      title: "ci: reorganize workflows",
+      labels: [{ name: "release:skip" }],
+    }),
+    true
+  );
+  assert.equal(
+    shouldSkipPullRequest({
+      title: "chore: bump version to 2.50.0",
+      labels: [],
+    }),
+    true
+  );
+  assert.equal(
+    shouldSkipPullRequest({
+      title: "docs: add a guide",
+      labels: [],
+    }),
+    false
+  );
+});
+
 test("renders the three required release note sections", () => {
   const notes = renderReleaseNotes({
     repository: "nervosnetwork/docs.nervos.org",
@@ -80,15 +138,20 @@ test("renders the three required release note sections", () => {
     pullRequests: [
       {
         title: "fix: repair a redirect",
+        body: `## Release note
+
+Repaired the redirect from the legacy quick-start URL.`,
         labels: [],
         merged_at: "2026-07-24T01:00:00Z",
+        number: 1,
         html_url: "https://github.com/nervosnetwork/docs.nervos.org/pull/1",
         user: { login: "maintainer" },
       },
       {
-        title: "chore: bump version",
+        title: "chore: bump version to 2.50.0",
         labels: [],
         merged_at: "2026-07-24T02:00:00Z",
+        number: 2,
         html_url: "https://github.com/nervosnetwork/docs.nervos.org/pull/2",
         user: { login: "release-bot" },
       },
@@ -98,9 +161,10 @@ test("renders the three required release note sections", () => {
   assert.match(notes, /## New Content/);
   assert.match(notes, /No new content in this release/);
   assert.match(notes, /## Fixes/);
-  assert.match(notes, /fix: repair a redirect/);
+  assert.match(notes, /Repaired the redirect from the legacy quick-start URL/);
   assert.match(notes, /## Other/);
-  assert.match(notes, /chore: bump version/);
+  assert.match(notes, /No other changes in this release/);
+  assert.doesNotMatch(notes, /bump version/);
   assert.match(notes, /v2\.49\.0\.\.\.v2\.50\.0/);
 });
 

--- a/scripts/release/release-lib.test.mjs
+++ b/scripts/release/release-lib.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyPullRequest,
+  evaluateCommitValidation,
+  renderReleaseNotes,
+  resolveTargetVersion,
+} from "./release-lib.mjs";
+
+test("resolves semantic version bumps", () => {
+  assert.equal(
+    resolveTargetVersion({
+      currentVersion: "2.49.0",
+      bumpType: "minor",
+      customVersion: "",
+    }),
+    "2.50.0"
+  );
+  assert.equal(
+    resolveTargetVersion({
+      currentVersion: "2.49.0",
+      bumpType: "patch",
+      customVersion: "",
+    }),
+    "2.49.1"
+  );
+  assert.equal(
+    resolveTargetVersion({
+      currentVersion: "2.49.0",
+      bumpType: "custom",
+      customVersion: "v3.0.0",
+    }),
+    "3.0.0"
+  );
+});
+
+test("rejects an older custom version", () => {
+  assert.throws(
+    () =>
+      resolveTargetVersion({
+        currentVersion: "2.49.0",
+        bumpType: "custom",
+        customVersion: "2.48.0",
+      }),
+    /must be newer/
+  );
+});
+
+test("classifies release notes from labels and conventional titles", () => {
+  assert.equal(
+    classifyPullRequest({ title: "docs: add a guide", labels: [] }),
+    "newContent"
+  );
+  assert.equal(
+    classifyPullRequest({ title: "fix: repair a redirect", labels: [] }),
+    "fixes"
+  );
+  assert.equal(
+    classifyPullRequest({
+      title: "chore: update dependencies",
+      labels: [{ name: "release:fix" }],
+    }),
+    "fixes"
+  );
+  assert.equal(
+    classifyPullRequest({
+      title: "chore: bump version",
+      labels: [],
+    }),
+    "other"
+  );
+});
+
+test("renders the three required release note sections", () => {
+  const notes = renderReleaseNotes({
+    repository: "nervosnetwork/docs.nervos.org",
+    previousTag: "v2.49.0",
+    tag: "v2.50.0",
+    pullRequests: [
+      {
+        title: "fix: repair a redirect",
+        labels: [],
+        merged_at: "2026-07-24T01:00:00Z",
+        html_url: "https://github.com/nervosnetwork/docs.nervos.org/pull/1",
+        user: { login: "maintainer" },
+      },
+      {
+        title: "chore: bump version",
+        labels: [],
+        merged_at: "2026-07-24T02:00:00Z",
+        html_url: "https://github.com/nervosnetwork/docs.nervos.org/pull/2",
+        user: { login: "release-bot" },
+      },
+    ],
+  });
+
+  assert.match(notes, /## New Content/);
+  assert.match(notes, /No new content in this release/);
+  assert.match(notes, /## Fixes/);
+  assert.match(notes, /fix: repair a redirect/);
+  assert.match(notes, /## Other/);
+  assert.match(notes, /chore: bump version/);
+  assert.match(notes, /v2\.49\.0\.\.\.v2\.50\.0/);
+});
+
+test("waits for the expected checks and fails fast on errors", () => {
+  assert.deepEqual(
+    evaluateCommitValidation({
+      checkRuns: [
+        {
+          name: "node-js",
+          status: "completed",
+          conclusion: "success",
+        },
+      ],
+      statuses: [{ context: "Vercel", state: "success" }],
+      minimumNodeRuns: 1,
+    }).state,
+    "success"
+  );
+
+  assert.deepEqual(
+    evaluateCommitValidation({
+      checkRuns: [
+        {
+          name: "node-js",
+          status: "completed",
+          conclusion: "failure",
+        },
+      ],
+      statuses: [{ context: "Vercel", state: "success" }],
+      minimumNodeRuns: 1,
+    }).state,
+    "failure"
+  );
+
+  assert.deepEqual(
+    evaluateCommitValidation({
+      checkRuns: [
+        {
+          name: "node-js",
+          status: "in_progress",
+          conclusion: null,
+        },
+      ],
+      statuses: [],
+      minimumNodeRuns: 2,
+    }).state,
+    "pending"
+  );
+});

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -1,0 +1,903 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  compareVersions,
+  evaluateCommitValidation,
+  parseVersion,
+  renderReleaseNotes,
+  resolveTargetVersion,
+} from "./release-lib.mjs";
+
+const DEVELOP_BRANCH = "develop";
+const MASTER_BRANCH = "master";
+const PACKAGE_PATH = "website/package.json";
+const DEFAULT_TIMEOUT_SECONDS = 20 * 60;
+const DEFAULT_POLL_SECONDS = 15;
+
+function requiredEnvironment(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function shellQuote(value) {
+  const text = String(value);
+  return /^[A-Za-z0-9_./:@=-]+$/.test(text)
+    ? text
+    : `'${text.replaceAll("'", "'\\''")}'`;
+}
+
+function run(command, args, options = {}) {
+  const { allowFailure = false, capture = true, cwd = process.cwd() } = options;
+  console.log(`$ ${[command, ...args].map(shellQuote).join(" ")}`);
+
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: process.env,
+    stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0 && !allowFailure) {
+    const details = [result.stdout, result.stderr]
+      .filter(Boolean)
+      .join("\n")
+      .trim();
+    throw new Error(
+      `${command} exited with ${result.status}${details ? `:\n${details}` : ""}`
+    );
+  }
+
+  return {
+    status: result.status,
+    stdout: result.stdout?.trim() ?? "",
+    stderr: result.stderr?.trim() ?? "",
+  };
+}
+
+function git(args, options = {}) {
+  return run("git", args, options);
+}
+
+function readPackageVersion(filePath = PACKAGE_PATH) {
+  const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  return parseVersion(contents.version).value;
+}
+
+function writePackageVersion(version, filePath = PACKAGE_PATH) {
+  const contents = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  contents.version = parseVersion(version).value;
+  fs.writeFileSync(filePath, `${JSON.stringify(contents, null, 2)}\n`);
+}
+
+function appendSummary(markdown) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${markdown.trim()}\n`);
+  }
+}
+
+function encodeQuery(parameters) {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(parameters)) {
+    if (value !== undefined && value !== null) {
+      search.set(key, String(value));
+    }
+  }
+  return search.toString();
+}
+
+class GitHubClient {
+  constructor({ repository, token }) {
+    this.repository = repository;
+    this.token = token;
+    this.apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  }
+
+  async request(method, endpoint, options = {}) {
+    const { allow404 = false, body } = options;
+    const response = await fetch(`${this.apiUrl}${endpoint}`, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const responseText = await response.text();
+    let data = null;
+
+    if (responseText) {
+      try {
+        data = JSON.parse(responseText);
+      } catch {
+        data = responseText;
+      }
+    }
+
+    if (response.status === 404 && allow404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      const message =
+        typeof data === "object" && data?.message ? data.message : responseText;
+      throw new Error(
+        `${method} ${endpoint} failed (${response.status}): ${message}`
+      );
+    }
+
+    return data;
+  }
+
+  get(endpoint, options) {
+    return this.request("GET", endpoint, options);
+  }
+
+  post(endpoint, body) {
+    return this.request("POST", endpoint, { body });
+  }
+
+  put(endpoint, body) {
+    return this.request("PUT", endpoint, { body });
+  }
+
+  async commit(ref) {
+    return this.get(
+      `/repos/${this.repository}/commits/${encodeURIComponent(ref)}`
+    );
+  }
+
+  async ref(kind, name) {
+    return this.get(`/repos/${this.repository}/git/ref/${kind}/${name}`, {
+      allow404: true,
+    });
+  }
+
+  async packageVersion(ref) {
+    const query = encodeQuery({ ref });
+    const response = await this.get(
+      `/repos/${this.repository}/contents/${PACKAGE_PATH}?${query}`
+    );
+    const contents = Buffer.from(
+      response.content.replaceAll("\n", ""),
+      "base64"
+    ).toString("utf8");
+    return parseVersion(JSON.parse(contents).version).value;
+  }
+
+  async latestRelease() {
+    return this.get(`/repos/${this.repository}/releases/latest`, {
+      allow404: true,
+    });
+  }
+
+  async releaseByTag(tag) {
+    return this.get(
+      `/repos/${this.repository}/releases/tags/${encodeURIComponent(tag)}`,
+      { allow404: true }
+    );
+  }
+
+  async pulls({ base, head, state = "all" }) {
+    const owner = this.repository.split("/")[0];
+    const normalizedHead =
+      head && !head.includes(":") ? `${owner}:${head}` : head;
+    const query = encodeQuery({
+      base,
+      head: normalizedHead,
+      state,
+      per_page: 100,
+      sort: "updated",
+      direction: "desc",
+    });
+    return this.get(`/repos/${this.repository}/pulls?${query}`);
+  }
+
+  async findPull({ base, head, title }) {
+    const pulls = await this.pulls({ base, head });
+    return pulls.find((pullRequest) => pullRequest.title === title) ?? null;
+  }
+
+  async findMergedPullByTitle({ base, title }) {
+    const pulls = await this.pulls({ base, state: "closed" });
+    return (
+      pulls.find(
+        (pullRequest) => pullRequest.title === title && pullRequest.merged_at
+      ) ?? null
+    );
+  }
+
+  createPull({ base, body, head, title }) {
+    return this.post(`/repos/${this.repository}/pulls`, {
+      base,
+      body,
+      head,
+      title,
+    });
+  }
+
+  async mergePull(pullRequest, expectedHeadSha) {
+    const response = await this.put(
+      `/repos/${this.repository}/pulls/${pullRequest.number}/merge`,
+      {
+        merge_method: "merge",
+        sha: expectedHeadSha,
+      }
+    );
+
+    if (!response.merged) {
+      throw new Error(
+        `PR #${pullRequest.number} was not merged: ${response.message}`
+      );
+    }
+
+    return response.sha;
+  }
+
+  async waitForValidation(
+    sha,
+    {
+      minimumNodeRuns,
+      pollSeconds = DEFAULT_POLL_SECONDS,
+      timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+    }
+  ) {
+    const deadline = Date.now() + timeoutSeconds * 1000;
+    let lastMessage = "";
+
+    while (Date.now() < deadline) {
+      const [checkRunsResponse, statusesResponse] = await Promise.all([
+        this.get(
+          `/repos/${this.repository}/commits/${sha}/check-runs?per_page=100`
+        ),
+        this.get(`/repos/${this.repository}/commits/${sha}/status`),
+      ]);
+      const evaluation = evaluateCommitValidation({
+        checkRuns: checkRunsResponse.check_runs,
+        statuses: statusesResponse.statuses,
+        minimumNodeRuns,
+      });
+
+      if (evaluation.message !== lastMessage) {
+        console.log(`Validation ${sha.slice(0, 7)}: ${evaluation.message}`);
+        lastMessage = evaluation.message;
+      }
+
+      if (evaluation.state === "success") {
+        return;
+      }
+
+      if (evaluation.state === "failure") {
+        throw new Error(
+          `Validation failed for ${sha.slice(0, 7)}: ${evaluation.message}`
+        );
+      }
+
+      await delay(pollSeconds * 1000);
+    }
+
+    throw new Error(
+      `Timed out after ${timeoutSeconds}s waiting for validation of ${sha}`
+    );
+  }
+
+  async associatedPullRequests(commitShas) {
+    const pullRequests = new Map();
+    const batchSize = 10;
+
+    for (let index = 0; index < commitShas.length; index += batchSize) {
+      const batch = commitShas.slice(index, index + batchSize);
+      const responses = await Promise.all(
+        batch.map((sha) =>
+          this.get(
+            `/repos/${this.repository}/commits/${sha}/pulls?per_page=100`
+          )
+        )
+      );
+
+      for (const response of responses) {
+        for (const pullRequest of response) {
+          if (
+            pullRequest.merged_at &&
+            pullRequest.base?.ref === DEVELOP_BRANCH
+          ) {
+            pullRequests.set(pullRequest.number, pullRequest);
+          }
+        }
+      }
+    }
+
+    return [...pullRequests.values()];
+  }
+
+  createTag(tag, sha) {
+    return this.post(`/repos/${this.repository}/git/refs`, {
+      ref: `refs/tags/${tag}`,
+      sha,
+    });
+  }
+
+  createRelease({ body, tag }) {
+    return this.post(`/repos/${this.repository}/releases`, {
+      body,
+      draft: false,
+      make_latest: "true",
+      name: tag,
+      prerelease: false,
+      tag_name: tag,
+      target_commitish: MASTER_BRANCH,
+    });
+  }
+}
+
+function versionPullTitle(version) {
+  return `chore: bump version to ${version}`;
+}
+
+function masterPullTitle(version) {
+  return `Merge ${version} into master`;
+}
+
+function runLocalReleaseValidation() {
+  run("yarn", ["install", "--frozen-lockfile"], {
+    capture: false,
+    cwd: path.join(process.cwd(), "website"),
+  });
+  run("yarn", ["prettier", "--check", "package.json"], {
+    capture: false,
+    cwd: path.join(process.cwd(), "website"),
+  });
+  run("yarn", ["build"], {
+    capture: false,
+    cwd: path.join(process.cwd(), "website"),
+  });
+  git(["diff", "--check"]);
+
+  const changedFiles = git(["diff", "--name-only"])
+    .stdout.split("\n")
+    .filter(Boolean);
+  if (changedFiles.length !== 1 || changedFiles[0] !== PACKAGE_PATH) {
+    throw new Error(
+      `Version preparation changed unexpected files: ${
+        changedFiles.join(", ") || "(none)"
+      }`
+    );
+  }
+}
+
+function hasReleaseContentChanges() {
+  const result = git(
+    [
+      "diff",
+      "--quiet",
+      "origin/master",
+      "origin/develop",
+      "--",
+      ".",
+      ":(exclude)website/package.json",
+    ],
+    { allowFailure: true }
+  );
+
+  if (![0, 1].includes(result.status)) {
+    throw new Error("Unable to compare master and develop");
+  }
+  return result.status === 1;
+}
+
+function releaseRunMarker(runId) {
+  return `<!-- release-run-id: ${runId} -->`;
+}
+
+function masterBaseMarker(sha) {
+  return `<!-- release-master-base: ${sha} -->`;
+}
+
+function logPlan({
+  currentVersion,
+  developSha,
+  developVersion,
+  previousTag,
+  repository,
+  targetVersion,
+}) {
+  const tag = `v${targetVersion}`;
+  appendSummary(`## Release plan: ${tag}
+
+| Field | Value |
+| --- | --- |
+| Repository | \`${repository}\` |
+| Previous release | \`${previousTag}\` |
+| Released version | \`${currentVersion}\` |
+| Develop version | \`${developVersion}\` |
+| Develop snapshot | \`${developSha}\` |
+| Target version | \`${targetVersion}\` |
+| Release branch | \`release/${tag}\` |`);
+}
+
+async function collectReleaseNotes({
+  client,
+  previousTag,
+  repository,
+  runId,
+  tag,
+  targetSha,
+}) {
+  git(["fetch", "origin", MASTER_BRANCH, DEVELOP_BRANCH, "--tags"]);
+  const commitShas = git(["rev-list", `${previousTag}..${targetSha}`])
+    .stdout.split("\n")
+    .filter(Boolean);
+  const pullRequests = await client.associatedPullRequests(commitShas);
+  const notes = renderReleaseNotes({
+    previousTag,
+    pullRequests,
+    repository,
+    tag,
+  });
+  return `${notes}\n\n${releaseRunMarker(runId)}`;
+}
+
+async function waitForRef(client, kind, name, timeoutSeconds = 60) {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  while (Date.now() < deadline) {
+    const ref = await client.ref(kind, name);
+    if (ref) {
+      return ref;
+    }
+    await delay(2000);
+  }
+  throw new Error(`Timed out waiting for ${kind}/${name}`);
+}
+
+async function ensureVersionBranch({
+  client,
+  developSha,
+  releaseBranch,
+  targetVersion,
+}) {
+  const remoteRef = await client.ref("heads", releaseBranch);
+
+  if (remoteRef) {
+    const remoteVersion = await client.packageVersion(releaseBranch);
+    if (remoteVersion !== targetVersion) {
+      throw new Error(
+        `${releaseBranch} contains version ${remoteVersion}, expected ${targetVersion}`
+      );
+    }
+    const commit = await client.commit(remoteRef.object.sha);
+    const baseSha = commit.parents?.[0]?.sha;
+    if (!baseSha) {
+      throw new Error(`Cannot determine the base commit of ${releaseBranch}`);
+    }
+    return {
+      baseSha,
+      headSha: remoteRef.object.sha,
+      reused: true,
+    };
+  }
+
+  git(["switch", "--create", releaseBranch, developSha]);
+  writePackageVersion(targetVersion);
+  runLocalReleaseValidation();
+  git(["add", PACKAGE_PATH]);
+  git(["commit", "-m", versionPullTitle(targetVersion)]);
+  git(["push", "--set-upstream", "origin", releaseBranch], {
+    capture: false,
+  });
+
+  const createdRef = await waitForRef(client, "heads", releaseBranch);
+  return {
+    baseSha: developSha,
+    headSha: createdRef.object.sha,
+    reused: false,
+  };
+}
+
+async function ensureVersionPull({ client, releaseBranch, targetVersion }) {
+  const title = versionPullTitle(targetVersion);
+  let pullRequest = await client.findPull({
+    base: DEVELOP_BRANCH,
+    head: releaseBranch,
+    title,
+  });
+
+  if (!pullRequest) {
+    const otherVersionPull = (
+      await client.pulls({
+        base: DEVELOP_BRANCH,
+        state: "open",
+      })
+    ).find((candidate) =>
+      candidate.title.startsWith("chore: bump version to ")
+    );
+    if (otherVersionPull) {
+      throw new Error(
+        `Another version PR is already open: #${otherVersionPull.number}`
+      );
+    }
+
+    pullRequest = await client.createPull({
+      base: DEVELOP_BRANCH,
+      body: `Automated version bump for v${targetVersion}.`,
+      head: releaseBranch,
+      title,
+    });
+  }
+
+  if (pullRequest.state === "closed" && !pullRequest.merged_at) {
+    throw new Error(
+      `Version PR #${pullRequest.number} was closed without merging`
+    );
+  }
+  return pullRequest;
+}
+
+async function ensureVersionMerged({
+  branchState,
+  client,
+  targetVersion,
+  versionPull,
+}) {
+  if (versionPull.merged_at) {
+    return versionPull.merge_commit_sha;
+  }
+
+  const currentDevelopSha = (await client.commit(DEVELOP_BRANCH)).sha;
+  if (currentDevelopSha !== branchState.baseSha) {
+    throw new Error(
+      `develop moved from ${branchState.baseSha} to ${currentDevelopSha} during the release. Close the version PR, delete its branch, and start a new release.`
+    );
+  }
+
+  await client.waitForValidation(branchState.headSha, {
+    minimumNodeRuns: 2,
+  });
+  return client.mergePull(versionPull, branchState.headSha);
+}
+
+async function ensureMasterPull({
+  client,
+  releaseDevelopSha,
+  repository,
+  targetVersion,
+}) {
+  const title = masterPullTitle(targetVersion);
+  const owner = repository.split("/")[0];
+  let pullRequest = await client.findPull({
+    base: MASTER_BRANCH,
+    head: `${owner}:${DEVELOP_BRANCH}`,
+    title,
+  });
+
+  if (pullRequest) {
+    return pullRequest;
+  }
+
+  const openMasterPulls = await client.pulls({
+    base: MASTER_BRANCH,
+    state: "open",
+  });
+  if (openMasterPulls.length > 0) {
+    throw new Error(
+      `Another PR to master is already open: #${openMasterPulls[0].number}`
+    );
+  }
+
+  const masterSha = (await client.commit(MASTER_BRANCH)).sha;
+  return client.createPull({
+    base: MASTER_BRANCH,
+    body: [
+      `Automated production release for v${targetVersion}.`,
+      "",
+      masterBaseMarker(masterSha),
+    ].join("\n"),
+    head: DEVELOP_BRANCH,
+    title,
+  });
+}
+
+function masterBaseFromPull(pullRequest) {
+  const match = /<!-- release-master-base: ([0-9a-f]{40}) -->/.exec(
+    pullRequest.body ?? ""
+  );
+  return match?.[1] ?? pullRequest.base?.sha;
+}
+
+async function ensureMasterMerged({ client, masterPull, releaseDevelopSha }) {
+  if (masterPull.merged_at) {
+    return masterPull.merge_commit_sha;
+  }
+
+  const currentDevelopSha = (await client.commit(DEVELOP_BRANCH)).sha;
+  if (
+    currentDevelopSha !== releaseDevelopSha ||
+    masterPull.head.sha !== releaseDevelopSha
+  ) {
+    throw new Error(
+      "develop changed after the version merge; refusing to release an unvalidated snapshot"
+    );
+  }
+
+  const expectedMasterSha = masterBaseFromPull(masterPull);
+  const currentMasterSha = (await client.commit(MASTER_BRANCH)).sha;
+  if (currentMasterSha !== expectedMasterSha) {
+    throw new Error(
+      `master moved from ${expectedMasterSha} to ${currentMasterSha}; recreate the release PR`
+    );
+  }
+
+  await client.waitForValidation(releaseDevelopSha, {
+    minimumNodeRuns: 2,
+  });
+  return client.mergePull(masterPull, releaseDevelopSha);
+}
+
+async function ensureTag(client, tag, targetSha) {
+  const existing = await client.ref("tags", tag);
+  if (!existing) {
+    await client.createTag(tag, targetSha);
+    return;
+  }
+
+  if (existing.object.type !== "commit" || existing.object.sha !== targetSha) {
+    throw new Error(`${tag} already exists and does not point to ${targetSha}`);
+  }
+}
+
+async function main() {
+  const repository = requiredEnvironment("GITHUB_REPOSITORY");
+  const token = requiredEnvironment("GH_TOKEN");
+  const runId = requiredEnvironment("GITHUB_RUN_ID");
+  const bumpType = process.env.RELEASE_BUMP?.trim() || "minor";
+  const customVersion = process.env.RELEASE_VERSION?.trim() || "";
+  const dryRun = process.env.RELEASE_DRY_RUN === "true";
+  const refName = process.env.GITHUB_REF_NAME;
+
+  if (refName && refName !== DEVELOP_BRANCH) {
+    throw new Error(
+      `The release workflow must run from ${DEVELOP_BRANCH}, not ${refName}`
+    );
+  }
+
+  const client = new GitHubClient({ repository, token });
+  const latestRelease = await client.latestRelease();
+  if (!latestRelease) {
+    throw new Error("The repository has no previous GitHub Release");
+  }
+
+  const marker = releaseRunMarker(runId);
+  if (latestRelease.body?.includes(marker)) {
+    console.log(
+      `This workflow run already published ${latestRelease.tag_name}: ${latestRelease.html_url}`
+    );
+    appendSummary(`## Release already complete\n\n${latestRelease.html_url}`);
+    return;
+  }
+
+  git(["fetch", "origin", DEVELOP_BRANCH, MASTER_BRANCH, "--tags"]);
+  const developCommit = await client.commit(DEVELOP_BRANCH);
+  const developVersion = await client.packageVersion(DEVELOP_BRANCH);
+  const masterVersion = await client.packageVersion(MASTER_BRANCH);
+  const previousTag = latestRelease.tag_name;
+  const currentVersion = parseVersion(previousTag).value;
+
+  if (masterVersion !== currentVersion && masterVersion !== developVersion) {
+    throw new Error(
+      `master version ${masterVersion} matches neither the latest Release ${currentVersion} nor develop ${developVersion}`
+    );
+  }
+
+  const versionComparison = compareVersions(developVersion, currentVersion);
+  if (versionComparison < 0) {
+    throw new Error(
+      `develop version ${developVersion} is older than ${previousTag}`
+    );
+  }
+
+  let targetVersion;
+  const resuming = versionComparison > 0;
+  if (resuming) {
+    targetVersion = developVersion;
+    if (
+      bumpType === "custom" &&
+      parseVersion(customVersion).value !== targetVersion
+    ) {
+      throw new Error(
+        `An in-progress release targets ${targetVersion}, not ${customVersion}`
+      );
+    }
+    console.log(`Resuming the in-progress v${targetVersion} release`);
+  } else {
+    targetVersion = resolveTargetVersion({
+      bumpType,
+      currentVersion,
+      customVersion,
+    });
+  }
+
+  const tag = `v${targetVersion}`;
+  const releaseBranch = `release/${tag}`;
+  logPlan({
+    currentVersion,
+    developSha: developCommit.sha,
+    developVersion,
+    previousTag,
+    repository,
+    targetVersion,
+  });
+
+  const existingRelease = await client.releaseByTag(tag);
+  if (existingRelease) {
+    throw new Error(
+      `${tag} already exists from another workflow run: ${existingRelease.html_url}`
+    );
+  }
+
+  if (!resuming && !hasReleaseContentChanges()) {
+    throw new Error(
+      "develop has no unreleased content changes relative to master"
+    );
+  }
+
+  if (dryRun) {
+    const notes = await collectReleaseNotes({
+      client,
+      previousTag,
+      repository,
+      runId,
+      tag,
+      targetSha: developCommit.sha,
+    });
+    appendSummary(`## Dry run complete
+
+No branches, pull requests, tags, or releases were created.
+
+### Proposed release notes
+
+${notes.replace(marker, "").trim()}`);
+    return;
+  }
+
+  let branchState;
+  let versionPull;
+
+  if (resuming) {
+    const remoteRef = await client.ref("heads", releaseBranch);
+    if (remoteRef) {
+      branchState = await ensureVersionBranch({
+        client,
+        developSha: developCommit.sha,
+        releaseBranch,
+        targetVersion,
+      });
+      versionPull = await ensureVersionPull({
+        client,
+        releaseBranch,
+        targetVersion,
+      });
+    } else {
+      versionPull = await client.findMergedPullByTitle({
+        base: DEVELOP_BRANCH,
+        title: versionPullTitle(targetVersion),
+      });
+      if (!versionPull) {
+        throw new Error(
+          `develop is already ${targetVersion}, but no matching automated version PR or release branch exists`
+        );
+      }
+    }
+  } else {
+    branchState = await ensureVersionBranch({
+      client,
+      developSha: developCommit.sha,
+      releaseBranch,
+      targetVersion,
+    });
+    versionPull = await ensureVersionPull({
+      client,
+      releaseBranch,
+      targetVersion,
+    });
+  }
+
+  let releaseDevelopSha;
+  if (versionPull.merged_at) {
+    releaseDevelopSha = versionPull.merge_commit_sha;
+  } else {
+    releaseDevelopSha = await ensureVersionMerged({
+      branchState,
+      client,
+      targetVersion,
+      versionPull,
+    });
+  }
+
+  const currentDevelopSha = (await client.commit(DEVELOP_BRANCH)).sha;
+  if (currentDevelopSha !== releaseDevelopSha) {
+    throw new Error(
+      `develop moved after the version merge (${releaseDevelopSha} -> ${currentDevelopSha})`
+    );
+  }
+  await client.waitForValidation(releaseDevelopSha, {
+    minimumNodeRuns: 1,
+  });
+
+  const masterPull = await ensureMasterPull({
+    client,
+    releaseDevelopSha,
+    repository,
+    targetVersion,
+  });
+  const masterMergeSha = await ensureMasterMerged({
+    client,
+    masterPull,
+    releaseDevelopSha,
+  });
+
+  if ((await client.packageVersion(masterMergeSha)) !== targetVersion) {
+    throw new Error(
+      `master merge ${masterMergeSha} does not contain version ${targetVersion}`
+    );
+  }
+
+  await client.waitForValidation(masterMergeSha, {
+    minimumNodeRuns: 1,
+  });
+  await ensureTag(client, tag, masterMergeSha);
+
+  const notes = await collectReleaseNotes({
+    client,
+    previousTag,
+    repository,
+    runId,
+    tag,
+    targetSha: masterMergeSha,
+  });
+  const release = await client.createRelease({ body: notes, tag });
+  const verifiedRelease = await client.releaseByTag(tag);
+  const verifiedTag = await client.ref("tags", tag);
+  const latest = await client.latestRelease();
+
+  if (
+    !verifiedRelease ||
+    verifiedRelease.draft ||
+    verifiedRelease.prerelease ||
+    verifiedTag?.object.sha !== masterMergeSha ||
+    latest?.tag_name !== tag
+  ) {
+    throw new Error("Final GitHub Release verification failed");
+  }
+
+  appendSummary(`## Released ${tag}
+
+- Release: ${release.html_url}
+- Version PR: ${versionPull.html_url}
+- Production PR: ${masterPull.html_url}
+- Commit: \`${masterMergeSha}\`
+- CI and Vercel: passed`);
+}
+
+main().catch((error) => {
+  console.error(error.stack ?? error.message);
+  appendSummary(`## Release failed
+
+\`\`\`
+${error.message}
+\`\`\`
+
+The workflow stopped before performing any later release step. Fix the reported condition and re-run this workflow.`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- add a GitHub-only, one-click production release workflow
- preserve version and production PRs with regular merge commits
- wait for Node.js CI and Vercel at every release stage
- add drift detection, concurrency locking, dry runs, resumable failures, and duplicate-release protection
- generate categorized release notes and verify the final tag and Release
- document the GitHub App and production ruleset setup

## Validation

- `node --check scripts/release/release.mjs`
- `node --test scripts/release/*.test.mjs`
- Prettier checks for all new automation files
- actionlint 1.7.12 for both GitHub Actions workflows

## Required after merge

Create and install the release GitHub App, add `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`, and grant the App pull-request-only bypass access in the production ruleset. See `.github/RELEASE_AUTOMATION.md`.