### PR TITLE
fix: add redirects for legacy 404 paths from latest tracking report

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -347,6 +347,30 @@ const config = {
             from: "/docs/getting-started/blockchain-networks",
             to: "/docs/getting-started/ckb-networks",
           },
+          {
+            // Malformed external links that picked up trailing CJK punctuation
+            from: "/docs/script/intro-to-script))。",
+            to: "/docs/script/intro-to-script",
+          },
+          {
+            from: "/docs/getting-started/how-ckb-works))。",
+            to: "/docs/getting-started/how-ckb-works",
+          },
+          {
+            from: "/docs/concepts/ckb-vm",
+            to: "/docs/ckb-fundamentals/ckb-vm",
+          },
+          {
+            from: [
+              "/docs/tech-explanation/previous-output",
+              "/docs/tech-explanation/cellinput",
+            ],
+            to: "/docs/tech-explanation/inputs",
+          },
+          {
+            from: "/docs/basics/guides/testnet",
+            to: "/docs/node/run-testnet-node",
+          },
         ],
         createRedirects(existingPath) {
           if (


### PR DESCRIPTION
## Summary

Adds client-side redirects for 404 paths reported in the latest analytics tracking report:

| 404 path | Redirect target | Note |
| --- | --- | --- |
| `/docs/script/intro-to-script))。` | `/docs/script/intro-to-script` | malformed external link picked up trailing CJK punctuation |
| `/docs/getting-started/how-ckb-works))。` | `/docs/getting-started/how-ckb-works` | same malformed-link pattern |
| `/docs/concepts/ckb-vm` | `/docs/ckb-fundamentals/ckb-vm` | legacy path variant |
| `/docs/tech-explanation/previous-output` | `/docs/tech-explanation/inputs` | content merged into this page in the tech-explanation restructure |
| `/docs/tech-explanation/cellinput` | `/docs/tech-explanation/inputs` | same |
| `/docs/basics/guides/testnet/` | `/docs/node/run-testnet-node` | parallels existing `mainnet` → `run-mainnet-node` redirect |

Two other paths from the report (`/docs/basics/faq/general`, `/docs/tech-explanation/ckb-vm`) already have working redirects live from the previous round — their 404 events predate that deploy.

Also verified: no internal docs pages still link to any of these 404 paths (checked `website/docs`, `website/static`, sidebars, and config).

## Verification

- `yarn build` succeeds; redirect HTML files are emitted for all new paths (including the CJK-punctuation ones).
- Served the build locally and confirmed HTTP 200 for every variant, including percent-encoded forms (`%29%29%E3%80%82`) that browsers actually send, and both `/docs/basics/guides/testnet` and `/docs/basics/guides/testnet/`.