### PR TITLE
fix: explicitly bypass release PR reviews

### DIFF
--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -39,8 +39,9 @@ revoked when the job finishes.
 
 ### 3. Configure the production ruleset
 
-Edit the `production` ruleset that targets `master`. Add the installed
-GitHub App to **Bypass list** and select **For pull requests only**.
+Edit the `production` ruleset that targets `master` and the default
+branch (`develop`). Add the installed GitHub App to **Bypass list** and
+select **For pull requests only**.
 
 Keep the existing rules:
 
@@ -48,9 +49,10 @@ Keep the existing rules:
 - Allow regular merge only.
 - Block force pushes and deletion.
 
-The pull-request-only bypass lets the release App merge the production
-PR without a human approval, while preventing direct pushes to
-`master`. Both release PRs and merge commits remain in the audit log.
+The release script uses `gh pr merge --admin` to explicitly select this
+bypass after verifying the expected head commit, Node.js checks, and
+Vercel. The pull-request-only mode prevents direct pushes to protected
+branches. Both release PRs and merge commits remain in the audit log.
 
 ## Running a release
 

--- a/scripts/release/release-lib.mjs
+++ b/scripts/release/release-lib.mjs
@@ -1,5 +1,33 @@
 const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
+export function adminMergeArguments({
+  expectedHeadSha,
+  pullNumber,
+  repository,
+}) {
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error(`Invalid pull request number: ${pullNumber}`);
+  }
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) {
+    throw new Error(`Invalid repository: ${repository}`);
+  }
+  if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
+    throw new Error(`Invalid expected head SHA: ${expectedHeadSha}`);
+  }
+
+  return [
+    "pr",
+    "merge",
+    String(pullNumber),
+    "--repo",
+    repository,
+    "--admin",
+    "--merge",
+    "--match-head-commit",
+    expectedHeadSha,
+  ];
+}
+
 export function parseVersion(value) {
   const normalized = String(value ?? "")
     .trim()

--- a/scripts/release/release-lib.test.mjs
+++ b/scripts/release/release-lib.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  adminMergeArguments,
   classifyPullRequest,
   evaluateCommitValidation,
   releaseSummary,
@@ -9,6 +10,27 @@ import {
   resolveTargetVersion,
   shouldSkipPullRequest,
 } from "./release-lib.mjs";
+
+test("builds a guarded administrator merge command", () => {
+  assert.deepEqual(
+    adminMergeArguments({
+      expectedHeadSha: "a".repeat(40),
+      pullNumber: 877,
+      repository: "nervosnetwork/docs.nervos.org",
+    }),
+    [
+      "pr",
+      "merge",
+      "877",
+      "--repo",
+      "nervosnetwork/docs.nervos.org",
+      "--admin",
+      "--merge",
+      "--match-head-commit",
+      "a".repeat(40),
+    ]
+  );
+});
 
 test("resolves semantic version bumps", () => {
   assert.equal(

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 
 import {
+  adminMergeArguments,
   compareVersions,
   evaluateCommitValidation,
   parseVersion,
@@ -230,21 +231,26 @@ class GitHubClient {
   }
 
   async mergePull(pullRequest, expectedHeadSha) {
-    const response = await this.put(
-      `/repos/${this.repository}/pulls/${pullRequest.number}/merge`,
-      {
-        merge_method: "merge",
-        sha: expectedHeadSha,
-      }
+    run(
+      "gh",
+      adminMergeArguments({
+        expectedHeadSha,
+        pullNumber: pullRequest.number,
+        repository: this.repository,
+      }),
+      { capture: false }
     );
 
-    if (!response.merged) {
+    const mergedPull = await this.get(
+      `/repos/${this.repository}/pulls/${pullRequest.number}`
+    );
+    if (!mergedPull.merged_at || !mergedPull.merge_commit_sha) {
       throw new Error(
-        `PR #${pullRequest.number} was not merged: ${response.message}`
+        `PR #${pullRequest.number} did not report a merge commit after gh completed`
       );
     }
 
-    return response.sha;
+    return mergedPull.merge_commit_sha;
   }
 
   async waitForValidation(


### PR DESCRIPTION
## Summary

- keep the release GitHub App on the pull-request-only ruleset bypass
- explicitly merge validated release PRs with `gh pr merge --admin`
- pin the expected PR head SHA before bypassing approval requirements
- verify GitHub reports the resulting merge commit
- document that the production ruleset targets both `master` and `develop`

## Validation

- `node --check scripts/release/release.mjs`
- `node --test scripts/release/*.test.mjs`
- Prettier check for the changed release files
- `git diff --check`

## Release note

<!-- Internal release automation fix; add the `release:skip` label after creation. -->