### PR TITLE
fix: recover interrupted releases

### DIFF
--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -53,6 +53,9 @@ The release script uses `gh pr merge --admin` to explicitly select this
 bypass after verifying the expected head commit, Node.js checks, and
 Vercel. The pull-request-only mode prevents direct pushes to protected
 branches. Both release PRs and merge commits remain in the audit log.
+The release App must create the pull request for this bypass mode to apply.
+Closed, unmerged release pull requests are ignored so a later run can create
+a fresh App-authored pull request from a recreated release branch.
 
 ## Running a release
 

--- a/scripts/release/release-lib.mjs
+++ b/scripts/release/release-lib.mjs
@@ -28,6 +28,31 @@ export function adminMergeArguments({
   ];
 }
 
+export function selectReusablePullRequest(pullRequests, title) {
+  const matching = pullRequests.filter(
+    (pullRequest) => pullRequest.title === title
+  );
+
+  return (
+    matching.find((pullRequest) => pullRequest.state === "open") ??
+    matching.find((pullRequest) => pullRequest.merged_at) ??
+    null
+  );
+}
+
+export function shouldRetryGitHubRequest({
+  attempt,
+  maxAttempts,
+  method,
+  status,
+}) {
+  if (method !== "GET" || attempt >= maxAttempts) {
+    return false;
+  }
+
+  return status === undefined || status === 429 || status >= 500;
+}
+
 export function parseVersion(value) {
   const normalized = String(value ?? "")
     .trim()

--- a/scripts/release/release-lib.test.mjs
+++ b/scripts/release/release-lib.test.mjs
@@ -8,6 +8,8 @@ import {
   releaseSummary,
   renderReleaseNotes,
   resolveTargetVersion,
+  selectReusablePullRequest,
+  shouldRetryGitHubRequest,
   shouldSkipPullRequest,
 } from "./release-lib.mjs";
 
@@ -29,6 +31,79 @@ test("builds a guarded administrator merge command", () => {
       "--match-head-commit",
       "a".repeat(40),
     ]
+  );
+});
+
+test("ignores closed unmerged pull requests when resuming", () => {
+  const closed = {
+    number: 877,
+    title: "chore: bump version to 2.50.0",
+    state: "closed",
+    merged_at: null,
+  };
+  const open = {
+    number: 880,
+    title: "chore: bump version to 2.50.0",
+    state: "open",
+    merged_at: null,
+  };
+  const merged = {
+    number: 881,
+    title: "chore: bump version to 2.50.0",
+    state: "closed",
+    merged_at: "2026-07-31T15:30:00Z",
+  };
+
+  assert.equal(
+    selectReusablePullRequest([closed], closed.title),
+    null
+  );
+  assert.equal(
+    selectReusablePullRequest([closed, merged, open], closed.title),
+    open
+  );
+  assert.equal(
+    selectReusablePullRequest([closed, merged], closed.title),
+    merged
+  );
+});
+
+test("retries only transient read requests", () => {
+  assert.equal(
+    shouldRetryGitHubRequest({
+      attempt: 1,
+      maxAttempts: 4,
+      method: "GET",
+      status: undefined,
+    }),
+    true
+  );
+  assert.equal(
+    shouldRetryGitHubRequest({
+      attempt: 1,
+      maxAttempts: 4,
+      method: "GET",
+      status: 502,
+    }),
+    true
+  );
+  assert.equal(
+    shouldRetryGitHubRequest({
+      attempt: 4,
+      maxAttempts: 4,
+      method: "GET",
+      status: 502,
+    }),
+    false
+  );
+  assert.equal(
+    shouldRetryGitHubRequest({
+      attempt: 1,
+      maxAttempts: 4,
+      method: "POST",
+      status: 502,
+    }),
+    false
   );
 });
 

--- a/scripts/release/release.mjs
+++ b/scripts/release/release.mjs
@@ -12,6 +12,8 @@ import {
   parseVersion,
   renderReleaseNotes,
   resolveTargetVersion,
+  selectReusablePullRequest,
+  shouldRetryGitHubRequest,
 } from "./release-lib.mjs";
 
 const DEVELOP_BRANCH = "develop";
@@ -19,6 +21,7 @@ const MASTER_BRANCH = "master";
 const PACKAGE_PATH = "website/package.json";
 const DEFAULT_TIMEOUT_SECONDS = 20 * 60;
 const DEFAULT_POLL_SECONDS = 15;
+const DEFAULT_GET_ATTEMPTS = 4;
 
 function requiredEnvironment(name) {
   const value = process.env[name]?.trim();
@@ -108,39 +111,82 @@ class GitHubClient {
 
   async request(method, endpoint, options = {}) {
     const { allow404 = false, body } = options;
-    const response = await fetch(`${this.apiUrl}${endpoint}`, {
-      method,
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${this.token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-      body: body === undefined ? undefined : JSON.stringify(body),
-    });
-    const responseText = await response.text();
-    let data = null;
+    const maxAttempts = method === "GET" ? DEFAULT_GET_ATTEMPTS : 1;
 
-    if (responseText) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      let response;
       try {
-        data = JSON.parse(responseText);
-      } catch {
-        data = responseText;
+        response = await fetch(`${this.apiUrl}${endpoint}`, {
+          method,
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${this.token}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: body === undefined ? undefined : JSON.stringify(body),
+        });
+      } catch (error) {
+        if (
+          !shouldRetryGitHubRequest({
+            attempt,
+            maxAttempts,
+            method,
+            status: undefined,
+          })
+        ) {
+          throw error;
+        }
+        console.warn(
+          `${method} ${endpoint} failed (${error.message}); retrying ${attempt}/${maxAttempts}`
+        );
+        await delay(1000 * 2 ** (attempt - 1));
+        continue;
       }
+
+      const responseText = await response.text();
+      let data = null;
+
+      if (responseText) {
+        try {
+          data = JSON.parse(responseText);
+        } catch {
+          data = responseText;
+        }
+      }
+
+      if (response.status === 404 && allow404) {
+        return null;
+      }
+
+      if (
+        shouldRetryGitHubRequest({
+          attempt,
+          maxAttempts,
+          method,
+          status: response.status,
+        })
+      ) {
+        console.warn(
+          `${method} ${endpoint} failed (${response.status}); retrying ${attempt}/${maxAttempts}`
+        );
+        await delay(1000 * 2 ** (attempt - 1));
+        continue;
+      }
+
+      if (!response.ok) {
+        const message =
+          typeof data === "object" && data?.message
+            ? data.message
+            : responseText;
+        throw new Error(
+          `${method} ${endpoint} failed (${response.status}): ${message}`
+        );
+      }
+
+      return data;
     }
 
-    if (response.status === 404 && allow404) {
-      return null;
-    }
-
-    if (!response.ok) {
-      const message =
-        typeof data === "object" && data?.message ? data.message : responseText;
-      throw new Error(
-        `${method} ${endpoint} failed (${response.status}): ${message}`
-      );
-    }
-
-    return data;
+    throw new Error(`${method} ${endpoint} exhausted all retry attempts`);
   }
 
   get(endpoint, options) {
@@ -209,7 +255,7 @@ class GitHubClient {
 
   async findPull({ base, head, title }) {
     const pulls = await this.pulls({ base, head });
-    return pulls.find((pullRequest) => pullRequest.title === title) ?? null;
+    return selectReusablePullRequest(pulls, title);
   }
 
   async findMergedPullByTitle({ base, title }) {
@@ -543,11 +589,6 @@ async function ensureVersionPull({ client, releaseBranch, targetVersion }) {
     });
   }
 
-  if (pullRequest.state === "closed" && !pullRequest.merged_at) {
-    throw new Error(
-      `Version PR #${pullRequest.number} was closed without merging`
-    );
-  }
   return pullRequest;
 }
 


### PR DESCRIPTION
## Summary

- ignore closed, unmerged release PRs when resuming so the App can create a fresh PR
- continue reusing matching open or merged PRs
- retry transient GitHub API failures and 429/5xx responses for read-only GET requests
- keep write requests single-attempt to avoid duplicate PRs, tags, or releases
- document that pull-request-only bypass requires the release App to create the PR

## Validation

- `node --check scripts/release/release.mjs`
- `node --test scripts/release/*.test.mjs` (10/10 passed)
- Prettier check for changed release files
- `git diff --check`

## Release note

<!-- Internal release automation fix; add the `release:skip` label after creation. -->