### PR TITLE
docs: add ckb-debugger prerequisite note to simple-lock Step 3

### DIFF
--- a/website/docs/dapp/simple-lock.mdx
+++ b/website/docs/dapp/simple-lock.mdx
@@ -72,6 +72,16 @@ You can also read the full code online or download it <ExampleLink path="dApp/si
 
 ### Step 3: Build and Deploy the Script
 
+:::note Prerequisite
+
+Before building the contract, make sure `ckb-debugger` is installed and available in your PATH.
+
+The build process invokes `ckb-debugger` to compile the JavaScript/TypeScript contract into the CKB bytecode (`.bc`) artifact that will be deployed in the next step.
+
+If you haven't installed it yet, please follow the [Debug with ckb-debugger](/docs/script/rust/rust-debug#debug-with-ckb-debugger) guide before continuing.
+
+:::
+
 To compile the contract, navigate to the `root` directory and run:
 
 <CodeTabs


### PR DESCRIPTION
## Summary

Adds a prerequisite note box to **Step 3: Build and Deploy the Script** in the Simple Lock dApp tutorial, informing developers that `ckb-debugger` must be installed before building the contract.

Also simplifies the step by replacing verbose terminal output with concise `pnpm install` + `pnpm build` commands and linking to the existing ckb-debugger installation guide.