### PR TITLE
fix: add redirects for legacy 404 paths from latest tracking report

### DIFF
--- a/website/docs/mining/guide.mdx
+++ b/website/docs/mining/guide.mdx
@@ -74,6 +74,10 @@ Here are a few more helpful resources to see the hash rate, fees, and various fe
 - https://minerstat.com/coin/ckb/pools
 - https://wheretomine.io/coins/nervos
 
+{/* Anchor alias for legacy /getting-started/mine#configurations links */}
+
+<a id="configurations" />
+
 ## Step 5: Set Up and Configure Your CKB Miner
 
 Once you have your miner, wallet address, and pool account, you are ready to start mining. If this is the first time you're setting up a miner, there are a few things you may want to check.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -430,12 +430,6 @@ const config = {
             to: "/docs/integrate-wallets/intro-to-wallets",
           },
           {
-            // nervosj was the original name of the CKB Java SDK
-            // (now ckb-sdk-java)
-            from: ["/nervosj", "/nervosj.html"],
-            to: "/docs/sdk-and-devtool/java",
-          },
-          {
             // Retired labs tutorial; the archived version lives on docs-old
             from: "/docs/labs/sudtbycapsule",
             to: "https://docs-old.nervos.org/docs/labs/sudtbycapsule",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -408,6 +408,38 @@ const config = {
             from: "/blog/page/3",
             to: "/docs/script/rust/rust-example-sudt-script",
           },
+          {
+            // 2019-era docs routes (root-level URLs from the pre-Docusaurus
+            // site). Both extensionless and .html variants circulated in old
+            // bookmarks and external posts.
+            from: ["/getting-started/mine", "/getting-started/mine.html"],
+            to: "/docs/mining/guide",
+          },
+          {
+            from: [
+              "/getting-started/run-node",
+              "/getting-started/run-node.html",
+            ],
+            to: "/docs/node/node-overview",
+          },
+          {
+            from: [
+              "/references/neuron-wallet-guide.html",
+              "/references/neuron-wallet-guide",
+            ],
+            to: "/docs/integrate-wallets/intro-to-wallets",
+          },
+          {
+            // nervosj was the original name of the CKB Java SDK
+            // (now ckb-sdk-java)
+            from: ["/nervosj", "/nervosj.html"],
+            to: "/docs/sdk-and-devtool/java",
+          },
+          {
+            // Retired labs tutorial; the archived version lives on docs-old
+            from: "/docs/labs/sudtbycapsule",
+            to: "https://docs-old.nervos.org/docs/labs/sudtbycapsule",
+          },
         ],
         createRedirects(existingPath) {
           if (


### PR DESCRIPTION
## Summary

Adds client-side redirects for the remaining legacy 404 route clusters from the latest broken-journeys report, and preserves the `#configurations` deep link from the old mining URL.

### Internal-reference audit

Searched the full site source (`website/docs`, `website/src`, `website/static` incl. `llms.txt`/`llms-full.txt`, sidebars, config) for every reported path first. **No internal page links to any of these URLs** — all hits come from external bookmarks and old posts, so there was nothing to fix in content before adding redirects.

### New redirects

| From | To | Rationale |
|---|---|---|
| `/getting-started/mine`, `/getting-started/mine.html` | `/docs/mining/guide` | 2019-era mining guide (root-level URL scheme); current maintained mining guide |
| `/getting-started/run-node`, `/getting-started/run-node.html` | `/docs/node/node-overview` | 2019-era node onboarding; current maintained node section entry point |
| `/references/neuron-wallet-guide.html`, `/references/neuron-wallet-guide` | `/docs/integrate-wallets/intro-to-wallets` | Stale bookmarked Neuron guide; the maintained wallet hub links out to Neuron's official site |
| `/docs/labs/sudtbycapsule` | `https://docs-old.nervos.org/docs/labs/sudtbycapsule` | Retired labs tutorial; the original content is preserved on the archived site (same pattern as the existing `/docs/basics/guides/get-ckb` redirect and the `createRedirects` handling of all `/docs/labs/*` and `/docs/essays/*` paths) |

The old mining URL circulated with a `#configurations` fragment. The redirect plugin forwards the fragment to the target, so `website/docs/mining/guide.mdx` gains an invisible `<a id="configurations" />` anchor in front of "Step 5: Set Up and Configure Your CKB Miner" — legacy deep links land on the configuration section instead of the top of the page.

### Checked but intentionally not redirected

- **CITA routes** (`/cita`, RPC guide, cross-chain examples), **`/AppChain-AppChain-Docs/`**, and **`/nervosj`**: this content never existed in this repo's history or on the archived site (verified via commit-history search in both `nervosnetwork/docs.nervos.org` and the legacy `nervosnetwork/docs`), so there is no maintained or archive destination we control. Per the report's own note, these should not be blind-redirected to the homepage, so they are left as 404.
- `/nervosj` specifically: an earlier revision of this PR redirected it to `/docs/sdk-and-devtool/java` on the assumption that nervosj was the original name of `ckb-sdk-java`. That was wrong — `cryptape/nervosj` follows GitHub's rename redirect to `citahub/cita-sdk-java` ("Java library for … CITA", created 2018-07, before CKB existed), while `nervosnetwork/ckb-sdk-java` was created under its current name and `nervosnetwork/nervosj` returns 404 (GitHub preserves rename redirects indefinitely). nervosj was the AppChain (CITA) Java SDK, so its traffic belongs to the retired-product group above, not to the CKB Java SDK page. (H/t review feedback on this PR.)

### Verification

- `yarn build` passes (Docusaurus validates every redirect target at build time; all internal targets resolve).
- Confirmed the generated redirect pages exist with the expected targets, e.g. `build/getting-started/mine/index.html` → `/docs/mining/guide`, `build/references/neuron-wallet-guide.html/index.html` → `/docs/integrate-wallets/intro-to-wallets`, `build/docs/labs/sudtbycapsule/index.html` → `https://docs-old.nervos.org/docs/labs/sudtbycapsule`.
- Confirmed no `build/nervosj*` redirect page is generated (route intentionally left as 404), and that `build/docs/mining/guide/index.html` contains `id="configurations"`.
