### PR TITLE
Add OpenChainBench RPC latency benchmark link

### DIFF
--- a/website/docs/getting-started/rpcs.mdx
+++ b/website/docs/getting-started/rpcs.mdx
@@ -30,6 +30,8 @@ CKB RPCs are a set of programming interfaces provided by the Nervos CKB blockcha
 
 ## Public JSON RPC Nodes
 
+For live latency benchmarks across public Nervos CKB RPC nodes, see [OpenChainBench](https://openchainbench.com/benchmarks/ckb-rpc) — p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
+
 - These nodes are provided by community members, they may be unstable, incomplete or not work at all, use at your own risk.
 - You may use these nodes to try out or test some features, but you should not use them for production.
 - Since ckb v0.105.0, ckb already included indexer service, just use ckb jsonrpc url for indexer service.

--- a/website/docs/getting-started/rpcs.mdx
+++ b/website/docs/getting-started/rpcs.mdx
@@ -30,7 +30,7 @@ CKB RPCs are a set of programming interfaces provided by the Nervos CKB blockcha
 
 ## Public JSON RPC Nodes
 
-For live latency benchmarks across public Nervos CKB RPC nodes, see [OpenChainBench](https://openchainbench.com/benchmarks/ckb-rpc) — p50/p90/p99 measured every 60 seconds from US-East, EU-West and Singapore.
+For live latency benchmarks of public CKB RPC nodes, see [OpenChainBench](https://openchainbench.com/benchmarks/ckb-rpc).
 
 - These nodes are provided by community members, they may be unstable, incomplete or not work at all, use at your own risk.
 - You may use these nodes to try out or test some features, but you should not use them for production.


### PR DESCRIPTION
[OpenChainBench](https://openchainbench.com) is a live RPC latency benchmark that continuously measures p50/p90/p99 response times across public blockchain endpoints from US-East, EU-West and Singapore.

This PR adds a one-line contextual reference in the Public JSON RPC Nodes section pointing developers to the [CKB benchmark](https://openchainbench.com/benchmarks/ckb-rpc) (bench 219), which benchmarks public Nervos CKB RPC nodes every 60 seconds.