### PR TITLE
fix: add redirects for legacy 404 paths from latest tracking report

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -434,6 +434,59 @@ const config = {
             from: "/docs/labs/sudtbycapsule",
             to: "https://docs-old.nervos.org/docs/labs/sudtbycapsule",
           },
+          {
+            // Legacy intro routes. /docs/intro/overview predates the current
+            // information architecture; /docs/basics/introduction was the old
+            // "Basics" section index. Both were entry points for newcomers.
+            from: ["/docs/intro/overview", "/docs/basics/introduction"],
+            to: "/docs/getting-started/how-ckb-works",
+          },
+          {
+            // Old "layers & consensus" taxonomy; layering and PoW consensus
+            // are now covered together in the Nervos Blockchain overview
+            from: "/docs/basics/layers-consensus",
+            to: "/docs/ckb-fundamentals/nervos-blockchain",
+          },
+          {
+            // Old Reference section: its cell page became the Cell Model doc
+            from: "/docs/reference/cell",
+            to: "/docs/ckb-fundamentals/cell-model",
+          },
+          {
+            // Old Reference section landing page; the glossary is the modern
+            // dictionary-style reference
+            from: "/docs/reference/introduction",
+            to: "/docs/tech-explanation/glossary",
+          },
+          {
+            // Never a real page — circulated as a mistaken path version of
+            // the old /docs/Node#run-a-mainnet-node anchor
+            from: "/docs/node/run-a-mainnet-node",
+            to: "/docs/node/run-mainnet-node",
+          },
+          {
+            // The economics doc lived at this path before moving to
+            // assets-token-standards
+            from: "/docs/tech-explanation/economics",
+            to: "/docs/assets-token-standards/economics",
+          },
+          {
+            // 2019-era "CKB Architecture" page (cell/transaction/script/block
+            // data structures). Both section prefixes and both extensionless
+            // and .html variants circulated in old bookmarks.
+            from: [
+              "/basic-concepts/architecture",
+              "/basic-concepts/architecture.html",
+              "/technical-concepts/architecture",
+              "/technical-concepts/architecture.html",
+            ],
+            to: "/docs/getting-started/how-ckb-works",
+          },
+          {
+            // Retired essay; the archived version lives on docs-old
+            from: "/docs/essays/upgradability",
+            to: "https://docs-old.nervos.org/docs/essays/upgradability",
+          },
         ],
         createRedirects(existingPath) {
           if (


### PR DESCRIPTION
## Summary

Adds client-side redirects (`@docusaurus/plugin-client-redirects`) for the worthwhile 404s in the latest broken-journeys report. All paths in the report were hit via direct/bookmarked traffic, and none are referenced by the docs site itself (checked all sources + the tracked link-check baseline — zero internal references, so nothing to fix in-content).

| Broken path | Events | Redirects to | Why |
| --- | ---: | --- | --- |
| `/docs/intro/overview` | 2 | `/docs/getting-started/how-ckb-works` | Legacy intro route; How CKB Works is the modern onboarding intro |
| `/docs/basics/introduction` | 2 | `/docs/getting-started/how-ckb-works` | Old "Basics" section index ("essential topics for users of all technical levels") |
| `/docs/basics/layers-consensus/` | 2 | `/docs/ckb-fundamentals/nervos-blockchain` | Old taxonomy; layering + PoW consensus are covered together there |
| `/docs/reference/cell/` | 2 | `/docs/ckb-fundamentals/cell-model` | Pre-#213 `reference/cell.md` was the cell-model doc |
| `/docs/reference/introduction` | 2 | `/docs/tech-explanation/glossary` | Old Reference landing page ("use it like a dictionary") — the glossary is the modern equivalent |
| `/docs/node/run-a-mainnet-node` | 1 | `/docs/node/run-mainnet-node` | Never a real page — circulated as a path version of the old `/docs/Node#run-a-mainnet-node` anchor |
| `/docs/tech-explanation/economics` | 1 | `/docs/assets-token-standards/economics` | Matches the file move; consistent with existing `/docs/basics/concepts/economics` and `/docs/reference/economics` redirects |
| `/basic-concepts/architecture`, `/technical-concepts/architecture.html` | 3 | `/docs/getting-started/how-ckb-works` | 2019-era "CKB Architecture" page (cell/transaction/script/block data structures); both prefixes in extensionless + `.html` variants, mirroring the #893 pattern |
| `/docs/essays/upgradability` | 3 | `https://docs-old.nervos.org/docs/essays/upgradability` (200 ✓) | Retired essay, archived copy on docs-old (same pattern as `/docs/labs/sudtbycapsule`) |

**Skipped:** `/cita/#/reference/faq?...nonce...` — unrelated cross-site path (CITA docs), and hash-fragment routing can't be handled by static redirect files anyway.

## Verification

- `yarn build` succeeds; all 12 generated redirect pages confirmed in `website/build/` with the expected targets
- Every internal target verified as an existing page in the build output (and 200 on the live site)
- No existing redirect entries conflict with the new `from` paths