### PR TITLE
docs: improve store data on cell tutorial

### DIFF
--- a/examples/dApp/simple-lock/README.md
+++ b/examples/dApp/simple-lock/README.md
@@ -7,7 +7,7 @@ An educational CKB dApp that deploys a JavaScript hash-lock contract, creates a 
 ## Prerequisites
 
 - Git
-- Node.js 18.18 or later
+- Node.js 20 or later
 - pnpm
 - OffCKB
 - Rust and `ckb-debugger`

--- a/examples/dApp/store-data-on-cell/.gitignore
+++ b/examples/dApp/store-data-on-cell/.gitignore
@@ -1,2 +1,5 @@
 .parcel-cache
+.parcel-cache-build
+.parcel-cache-dev
+.parcel-dev
 dist

--- a/examples/dApp/store-data-on-cell/README.md
+++ b/examples/dApp/store-data-on-cell/README.md
@@ -38,11 +38,11 @@ Enter the funded Testnet private key in the dApp. Never use a Mainnet private ke
 
 ## Troubleshooting
 
-- **`offckb: command not found`:** If you use NVM, select the Node.js version where OffCKB was installed, or reinstall OffCKB for the active version.
+- **`offckb: command not found`:** If you use nvm, select the Node.js version where OffCKB was installed, or reinstall OffCKB for the active version.
 - **`Failed to fetch`:** Confirm `offckb node` is still running and the dApp reports `devnet · http://127.0.0.1:28114`.
 - **Wrong page or port:** Open the dApp at `http://localhost:1234`. Port `28114` is the RPC endpoint and does not serve the dApp UI.
 - **Port or database lock error:** Stop duplicate OffCKB processes, then run `offckb node` again.
-- **`TransactionFailedToResolve` or an unknown CellDep:** Restart `npm start` after an OffCKB upgrade or Devnet reset so the example refreshes its system-script references.
+- **`TransactionFailedToResolve` or an unknown CellDep:** Run `npm start` again after an OffCKB upgrade or Devnet reset so the example synchronizes its system-script references with the initialized Devnet.
 - **Confirmation timed out:** Select **Check again** to retry the same transaction. Do not select **Write** again unless you intend to submit another message.
 - **Parcel native binary error:** Switch to Node.js 20, remove `node_modules`, and run `npm install` again.
 

--- a/examples/dApp/store-data-on-cell/README.md
+++ b/examples/dApp/store-data-on-cell/README.md
@@ -1,5 +1,49 @@
-# Write & Read On-chain Data
+# Store Data on Cell
 
-This is a simple dApp example to show how to write and read data on the CKB blockchain. Read the step-by-step [tutorial](https://docs.nervos.org/docs/dapp/store-data-on-cell) to understand how it works and how to run it.
+This dApp writes a UTF-8 message to a CKB Cell and reads it back after the transaction is committed. Read the [step-by-step tutorial](https://docs.nervos.org/docs/dapp/store-data-on-cell) for an explanation of the code.
+
+## Prerequisites
+
+- Node.js 20 or later
+- [OffCKB](https://docs.nervos.org/docs/sdk-and-devtool/offckb)
+
+## Run on Devnet
+
+Start the local chain in one terminal:
+
+```bash
+offckb node
+```
+
+Keep that terminal open. In a second terminal, run:
+
+```bash
+npm install
+npm start
+```
+
+`npm start` refreshes the local system-script references from OffCKB before launching the frontend. Open [http://localhost:1234](http://localhost:1234). The dApp defaults to Devnet and connects to the OffCKB RPC proxy at `http://127.0.0.1:28114`.
+
+After you select **Write**, the dApp waits for the new Cell to become live before enabling **Read**. If confirmation times out, select **Check again** to retry the lookup without submitting another transaction.
+
+## Run on Testnet
+
+Create and fund a separate Testnet account, then run:
+
+```bash
+npm run start:testnet
+```
+
+Enter the funded Testnet private key in the dApp. Never use a Mainnet private key or Mainnet assets in this example.
+
+## Troubleshooting
+
+- **`offckb: command not found`:** If you use NVM, select the Node.js version where OffCKB was installed, or reinstall OffCKB for the active version.
+- **`Failed to fetch`:** Confirm `offckb node` is still running and the dApp reports `devnet · http://127.0.0.1:28114`.
+- **Wrong page or port:** Open the dApp at `http://localhost:1234`. Port `28114` is the RPC endpoint and does not serve the dApp UI.
+- **Port or database lock error:** Stop duplicate OffCKB processes, then run `offckb node` again.
+- **`TransactionFailedToResolve` or an unknown CellDep:** Restart `npm start` after an OffCKB upgrade or Devnet reset so the example refreshes its system-script references.
+- **Confirmation timed out:** Select **Check again** to retry the same transaction. Do not select **Write** again unless you intend to submit another message.
+- **Parcel native binary error:** Switch to Node.js 20, remove `node_modules`, and run `npm install` again.
 
 This example is originally modified from [hello, CKB](https://github.com/cryptape/ckb-tutorial) by [@Flouse](https://github.com/Flouse).

--- a/examples/dApp/store-data-on-cell/ccc-client.ts
+++ b/examples/dApp/store-data-on-cell/ccc-client.ts
@@ -1,7 +1,12 @@
 import { ccc, CellDepInfoLike, KnownScript, Script } from "@ckb-ccc/core";
 import systemScripts from "./system-scripts.json";
 
-export type Network = 'devnet' | 'testnet' | 'mainnet';
+export type Network = "devnet" | "testnet";
+
+export const NETWORK_RPC_URLS: Record<Network, string> = {
+  devnet: "http://127.0.0.1:28114",
+  testnet: "https://testnet.ckb.dev",
+};
 
 export type ScriptInfo = Pick<Script, "codeHash" | "hashType"> & { cellDeps: CellDepInfoLike[] };
 
@@ -21,12 +26,10 @@ export const DEVNET_SCRIPTS: Record<
 
 export function buildCccClient(network: Network) {
   const client =
-    network === "mainnet"
-      ? new ccc.ClientPublicMainnet()
-      : network === "testnet"
+    network === "testnet"
       ? new ccc.ClientPublicTestnet()
       : new ccc.ClientPublicTestnet({
-          url: "http://localhost:28114", // the default offckb devnet proxy rpc url
+          url: NETWORK_RPC_URLS.devnet,
           scripts: DEVNET_SCRIPTS as any,
         });
 
@@ -35,14 +38,24 @@ export function buildCccClient(network: Network) {
 
 export function readEnvNetwork(): Network {
   const network = process.env.NETWORK;
-  const defaultNetwork = 'testnet';
+  const defaultNetwork = "devnet";
   if (!network) return defaultNetwork;
 
-  if (!['devnet', 'testnet', 'mainnet'].includes(network)) {
-    return defaultNetwork;
+  if (network === "mainnet") {
+    throw new Error(
+      "Mainnet is not available for this tutorial example. Use Devnet or Testnet.",
+    );
+  }
+
+  if (!['devnet', 'testnet'].includes(network)) {
+    throw new Error(
+      `Unsupported NETWORK "${network}". Supported values are devnet and testnet.`,
+    );
   }
 
   return network as Network;
 }
 
-export const cccClient = buildCccClient(readEnvNetwork());
+export const activeNetwork = readEnvNetwork();
+export const activeRpcUrl = NETWORK_RPC_URLS[activeNetwork];
+export const cccClient = buildCccClient(activeNetwork);

--- a/examples/dApp/store-data-on-cell/index.html
+++ b/examples/dApp/store-data-on-cell/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>View and Transfer Balance</title>
+    <title>Store Data on Cell</title>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/dApp/store-data-on-cell/index.tsx
+++ b/examples/dApp/store-data-on-cell/index.tsx
@@ -8,10 +8,18 @@ import {
   shannonToCKB,
 } from "./lib";
 import { Script } from "@ckb-ccc/core";
+import { activeNetwork, activeRpcUrl } from "./ccc-client";
 
-const container = document.getElementById("root");
-const root = createRoot(container)
-root.render(<App />);
+function explainError(error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (
+    activeNetwork === "devnet" &&
+    /(failed to fetch|network|econnrefused|connect)/i.test(detail)
+  ) {
+    return "Cannot connect to the local Devnet at http://127.0.0.1:28114. Run offckb node and try again.";
+  }
+  return detail;
+}
 
 export function App() {
   // default value: first account privkey from offckb
@@ -24,14 +32,23 @@ export function App() {
 
   const [message, setMessage] = useState("hello common knowledge base!");
   const [txHash, setTxHash] = useState<string>();
+  const [confirmedMessage, setConfirmedMessage] = useState<string>();
+  const [displayedMessage, setDisplayedMessage] = useState<string>();
+  const [status, setStatus] = useState("Connecting to the selected network...");
+  const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     const updateFromInfo = async () => {
-      const { lockScript, address } = await generateAccountFromPrivateKey(privKey);
-      const capacity = await capacityOf(address);
-      setFromAddr(address);
-      setFromLock(lockScript);
-      setBalance(shannonToCKB(capacity).toString());
+      try {
+        const { lockScript, address } = await generateAccountFromPrivateKey(privKey);
+        const capacity = await capacityOf(address);
+        setFromAddr(address);
+        setFromLock(lockScript);
+        setBalance(shannonToCKB(capacity).toString());
+        setStatus("Ready.");
+      } catch (error) {
+        setStatus(explainError(error));
+      }
     };
 
     if (privKey) {
@@ -54,12 +71,48 @@ export function App() {
     }
   };
 
-  const enabled = +balance > 0 && message.length > 0;
-  const enabledRead = !!txHash;
+  const enabled = !busy && +balance > 0 && message.length > 0;
+  const enabledRead = !busy && confirmedMessage !== undefined;
+
+  const confirmMessage = async (submittedTxHash: string) => {
+    setBusy(true);
+    setStatus("Waiting for confirmation...");
+
+    try {
+      const storedMessage = await readOnChainMessage(submittedTxHash);
+      setConfirmedMessage(storedMessage);
+      setStatus("Message ready.");
+    } catch (error) {
+      setStatus(explainError(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const writeMessage = async () => {
+    setBusy(true);
+    setTxHash(undefined);
+    setConfirmedMessage(undefined);
+    setDisplayedMessage(undefined);
+    setStatus("Submitting transaction...");
+
+    try {
+      const submittedTxHash = await buildMessageTx(message, privKey);
+      setTxHash(submittedTxHash);
+      await confirmMessage(submittedTxHash);
+    } catch (error) {
+      setStatus(explainError(error));
+      setBusy(false);
+    }
+  };
 
   return (
     <div>
       <h1>Store Data on Cell</h1>
+      <p>
+        <strong>Network:</strong> {activeNetwork} · {activeRpcUrl}
+      </p>
+      <p role="status">{status}</p>
       <label htmlFor="private-key">Private Key: </label>&nbsp;
       <input
         id="private-key"
@@ -89,23 +142,33 @@ export function App() {
       <br />
       <button
         disabled={!enabled}
-        onClick={() => {
-          buildMessageTx(message, privKey).then(txHash => setTxHash(txHash));
-        }}
+        onClick={writeMessage}
       >
         Write
       </button>
       <hr />
-      {txHash && <li>tx Hash: {txHash}</li>}
+      {txHash && <p>Transaction hash: {txHash}</p>}
+      {txHash && confirmedMessage === undefined && !busy && (
+        <button onClick={() => confirmMessage(txHash)}>Check again</button>
+      )}
       <button
         disabled={!enabledRead}
         onClick={() => {
-          readOnChainMessage(txHash);
+          setDisplayedMessage(confirmedMessage);
+          setStatus("Message read.");
         }}
       >
         Read
       </button>
-     
+      {displayedMessage !== undefined && <p>Message: {displayedMessage}</p>}
     </div>
   );
 }
+
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Unable to find the application root element.");
+}
+
+createRoot(container).render(<App />);

--- a/examples/dApp/store-data-on-cell/lib.ts
+++ b/examples/dApp/store-data-on-cell/lib.ts
@@ -63,20 +63,36 @@ export async function buildMessageTx(
   await tx.completeInputsByCapacity(signer);
   await tx.completeFeeBy(signer, 1000);
   const txHash = await signer.sendTransaction(tx);
-  alert(`The transaction hash is ${txHash}`);
 
   return txHash;
 }
 
-export async function readOnChainMessage(txHash: string, index = "0x0") {
-  const cell = await cccClient.getCellLive({ txHash, index }, true);
-  if (cell == null) {
-    return alert("cell not found, please retry later");
+type ReadMessageOptions = {
+  intervalMs?: number;
+  maxAttempts?: number;
+};
+
+export async function readOnChainMessage(
+  txHash: string,
+  index = "0x0",
+  options: ReadMessageOptions = {},
+) {
+  const { intervalMs = 1000, maxAttempts = 30 } = options;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const cell = await cccClient.getCellLive({ txHash, index }, true);
+    if (cell != null) {
+      return hexToUtf8(cell.outputData);
+    }
+
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
   }
-  const data = cell.outputData;
-  const msg = hexToUtf8(data);
-  alert("read msg: " + msg);
-  return msg;
+
+  throw new Error(
+    "The message Cell is not live yet. Wait for the transaction to be committed, then try again.",
+  );
 }
 
 export function shannonToCKB(amount: bigint){

--- a/examples/dApp/store-data-on-cell/package-lock.json
+++ b/examples/dApp/store-data-on-cell/package-lock.json
@@ -17,12 +17,14 @@
       },
       "devDependencies": {
         "@types/node": "^20.12.11",
+        "cross-env": "^7.0.3",
         "crypto-browserify": "^3.12.0",
         "events": "^3.3.0",
         "parcel": "^2.15.4",
         "path-browserify": "^1.0.0",
         "process": "^0.11.10",
-        "stream-browserify": "^3.0.0"
+        "stream-browserify": "^3.0.0",
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -2889,6 +2891,25 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
@@ -2896,6 +2917,21 @@
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/crypto-browserify": {
@@ -3386,9 +3422,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3495,6 +3532,13 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/isomorphic-ws": {
       "version": "5.0.0",
@@ -4077,6 +4121,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pbkdf2": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
@@ -4377,6 +4431,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -4487,10 +4564,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "peer": true,
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4589,6 +4666,22 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which-typed-array": {

--- a/examples/dApp/store-data-on-cell/package.json
+++ b/examples/dApp/store-data-on-cell/package.json
@@ -8,7 +8,7 @@
     "clean": "node scripts/clean-dist.cjs",
     "start": "npm run sync:devnet && parcel index.html --dist-dir .parcel-dev --cache-dir .parcel-cache-dev",
     "start:testnet": "cross-env NETWORK=testnet parcel index.html --dist-dir .parcel-dev --cache-dir .parcel-cache-dev",
-    "build": "npm run sync:devnet && npm run clean && parcel build index.html --dist-dir dist --cache-dir .parcel-cache-build --public-url ./ && node scripts/verify-browser-bundle.cjs",
+    "build": "npm run clean && parcel build index.html --dist-dir dist --cache-dir .parcel-cache-build --public-url ./ && node scripts/verify-browser-bundle.cjs",
     "lint": "tsc --noEmit"
   },
   "keywords": [],

--- a/examples/dApp/store-data-on-cell/package.json
+++ b/examples/dApp/store-data-on-cell/package.json
@@ -2,9 +2,13 @@
   "name": "@offckb/write-and-read-message",
   "version": "0.1.0",
   "description": "",
+  "private": true,
   "scripts": {
-    "start": "parcel index.html",
-    "build": "parcel build index.html --dist-dir dist --public-url ./",
+    "sync:devnet": "node scripts/sync-devnet-system-scripts.cjs",
+    "clean": "node scripts/clean-dist.cjs",
+    "start": "npm run sync:devnet && parcel index.html --dist-dir .parcel-dev --cache-dir .parcel-cache-dev",
+    "start:testnet": "cross-env NETWORK=testnet parcel index.html --dist-dir .parcel-dev --cache-dir .parcel-cache-dev",
+    "build": "npm run sync:devnet && npm run clean && parcel build index.html --dist-dir dist --cache-dir .parcel-cache-build --public-url ./ && node scripts/verify-browser-bundle.cjs",
     "lint": "tsc --noEmit"
   },
   "keywords": [],
@@ -19,11 +23,13 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.11",
+    "cross-env": "^7.0.3",
     "crypto-browserify": "^3.12.0",
     "events": "^3.3.0",
     "parcel": "^2.15.4",
     "path-browserify": "^1.0.0",
     "process": "^0.11.10",
-    "stream-browserify": "^3.0.0"
+    "stream-browserify": "^3.0.0",
+    "typescript": "^5.8.2"
   }
 }

--- a/examples/dApp/store-data-on-cell/scripts/clean-dist.cjs
+++ b/examples/dApp/store-data-on-cell/scripts/clean-dist.cjs
@@ -1,0 +1,5 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const distDirectory = path.resolve(__dirname, "../dist");
+fs.rmSync(distDirectory, { recursive: true, force: true });

--- a/examples/dApp/store-data-on-cell/scripts/sync-devnet-system-scripts.cjs
+++ b/examples/dApp/store-data-on-cell/scripts/sync-devnet-system-scripts.cjs
@@ -1,0 +1,73 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const artifactPath = path.resolve(__dirname, "../system-scripts.json");
+
+function syncDevnetSystemScripts() {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "store-data-system-scripts-"),
+  );
+  const exportedPath = path.join(directory, "system-scripts.json");
+
+  try {
+    const result = spawnSync(
+      "offckb",
+      [
+        "system-scripts",
+        "--network",
+        "devnet",
+        "--export-style",
+        "ccc",
+        "--output",
+        exportedPath,
+      ],
+      {
+        stdio: "inherit",
+        shell: process.platform === "win32",
+      },
+    );
+
+    if (result.error) {
+      throw new Error(
+        `Unable to export OffCKB system scripts: ${result.error.message}`,
+      );
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `Unable to export OffCKB system scripts: offckb exited with code ${result.status}.`,
+      );
+    }
+
+    const current = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+    const exported = JSON.parse(fs.readFileSync(exportedPath, "utf8"));
+    if (!exported.devnet?.secp256k1_blake160_sighash_all?.script) {
+      throw new Error(
+        "The OffCKB export does not contain the Devnet secp256k1 system script.",
+      );
+    }
+
+    current.devnet = Object.fromEntries(
+      Object.entries(exported.devnet).map(([name, entry]) => [
+        name,
+        {
+          ...entry,
+          ...(current.devnet?.[name]?.file
+            ? { file: current.devnet[name].file }
+            : {}),
+        },
+      ]),
+    );
+    fs.writeFileSync(artifactPath, `${JSON.stringify(current, null, 2)}\n`);
+    console.log("Synchronized Devnet system scripts with OffCKB.");
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+if (require.main === module) {
+  syncDevnetSystemScripts();
+}
+
+module.exports = { syncDevnetSystemScripts };

--- a/examples/dApp/store-data-on-cell/scripts/verify-browser-bundle.cjs
+++ b/examples/dApp/store-data-on-cell/scripts/verify-browser-bundle.cjs
@@ -1,0 +1,56 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const distDirectory = path.resolve(__dirname, "../dist");
+const html = fs.readFileSync(path.join(distDirectory, "index.html"), "utf8");
+const failures = [];
+
+if (!html.includes("<title>Store Data on Cell</title>")) {
+  failures.push('generated page title is not "Store Data on Cell"');
+}
+
+const scriptMatch = html.match(
+  /<script[^>]+src=(?:"([^"]+)"|'([^']+)'|([^\s>]+))[^>]*>/,
+);
+if (!scriptMatch) {
+  failures.push("generated page has no JavaScript entry");
+} else {
+  const scriptSource = scriptMatch[1] ?? scriptMatch[2] ?? scriptMatch[3];
+  const scriptPath = path.join(distDirectory, scriptSource.replace(/^\//, ""));
+  if (!fs.existsSync(scriptPath)) {
+    failures.push(`generated JavaScript entry does not exist: ${scriptSource}`);
+  }
+}
+
+const importPatterns = [
+  /\bfrom\s*["']([^"']+)["']/g,
+  /\bimport\s*["']([^"']+)["']/g,
+];
+for (const filename of fs
+  .readdirSync(distDirectory)
+  .filter((entry) => entry.endsWith(".js"))) {
+  const script = fs.readFileSync(path.join(distDirectory, filename), "utf8");
+  const bareImports = new Set();
+
+  for (const pattern of importPatterns) {
+    for (const match of script.matchAll(pattern)) {
+      const specifier = match[1];
+      if (!specifier.startsWith(".") && !specifier.startsWith("/")) {
+        bareImports.add(specifier);
+      }
+    }
+  }
+
+  if (bareImports.size > 0) {
+    failures.push(
+      `${filename} contains bare imports: ${Array.from(bareImports).join(", ")}`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error(failures.map((failure) => `- ${failure}`).join("\n"));
+  process.exit(1);
+}
+
+console.log("Browser bundle verification passed.");

--- a/examples/dApp/store-data-on-cell/system-scripts.json
+++ b/examples/dApp/store-data-on-cell/system-scripts.json
@@ -10,7 +10,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
+                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
                 "index": 0
               },
               "depType": "depGroup"
@@ -29,7 +29,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 2
               },
               "depType": "code"
@@ -48,7 +48,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
+                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
                 "index": 1
               },
               "depType": "depGroup"
@@ -67,7 +67,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 5
               },
               "depType": "code"
@@ -86,7 +86,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 6
               },
               "depType": "code"
@@ -105,7 +105,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 7
               },
               "depType": "code"
@@ -114,7 +114,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
+                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
                 "index": 0
               },
               "depType": "depGroup"
@@ -133,7 +133,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 8
               },
               "depType": "code"
@@ -152,7 +152,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 9
               },
               "depType": "code"
@@ -171,7 +171,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 10
               },
               "depType": "code"
@@ -190,7 +190,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 11
               },
               "depType": "code"
@@ -209,7 +209,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 12
               },
               "depType": "code"
@@ -228,7 +228,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 13
               },
               "depType": "code"
@@ -247,7 +247,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 14
               },
               "depType": "code"
@@ -266,7 +266,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 15
               },
               "depType": "code"
@@ -285,7 +285,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
+                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
                 "index": 16
               },
               "depType": "code"
@@ -304,7 +304,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
+                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
                 "index": 3
               },
               "depType": "depGroup"
@@ -323,7 +323,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
+                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
                 "index": 4
               },
               "depType": "depGroup"
@@ -342,7 +342,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
+                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
                 "index": 2
               },
               "depType": "depGroup"

--- a/examples/dApp/store-data-on-cell/system-scripts.json
+++ b/examples/dApp/store-data-on-cell/system-scripts.json
@@ -10,7 +10,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
+                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
                 "index": 0
               },
               "depType": "depGroup"
@@ -29,7 +29,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 2
               },
               "depType": "code"
@@ -48,7 +48,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
+                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
                 "index": 1
               },
               "depType": "depGroup"
@@ -67,7 +67,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 5
               },
               "depType": "code"
@@ -86,7 +86,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 6
               },
               "depType": "code"
@@ -105,7 +105,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 7
               },
               "depType": "code"
@@ -114,7 +114,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
+                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
                 "index": 0
               },
               "depType": "depGroup"
@@ -133,7 +133,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 8
               },
               "depType": "code"
@@ -152,7 +152,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 9
               },
               "depType": "code"
@@ -171,7 +171,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 10
               },
               "depType": "code"
@@ -190,7 +190,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 11
               },
               "depType": "code"
@@ -209,7 +209,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 12
               },
               "depType": "code"
@@ -228,7 +228,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 13
               },
               "depType": "code"
@@ -247,7 +247,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 14
               },
               "depType": "code"
@@ -266,7 +266,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 15
               },
               "depType": "code"
@@ -285,7 +285,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x6141d3dc3ccd8cbe4f0870676649778dd0f0422cf19735fcdebfa003fa980a40",
+                "txHash": "0x1bb87da347a776a927ab6593e1e10304ca195f8e24279f039008d5e3115b1bf7",
                 "index": 16
               },
               "depType": "code"
@@ -304,7 +304,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
+                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
                 "index": 3
               },
               "depType": "depGroup"
@@ -323,7 +323,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
+                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
                 "index": 4
               },
               "depType": "depGroup"
@@ -342,7 +342,7 @@
           {
             "cellDep": {
               "outPoint": {
-                "txHash": "0x3adf8c8bf04842c83cdaa21072cd3c4f869e8f7448b68d9baa409f6dc09f09b6",
+                "txHash": "0x4d804f1495612631da202fe9902fa9899118554b08138cfe5dfb50e1ede76293",
                 "index": 2
               },
               "depType": "depGroup"

--- a/examples/dApp/store-data-on-cell/tsconfig.json
+++ b/examples/dApp/store-data-on-cell/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "ES2015"],
+    "target": "ES2020",
     "jsx": "react",
     "module": "nodenext",
     "moduleResolution": "nodenext",

--- a/website/docs/dapp/SetupProject.tsx
+++ b/website/docs/dapp/SetupProject.tsx
@@ -3,6 +3,8 @@ import Content from "./_SetupProjectContent.mdx";
 
 export interface SetupProjectProp {
   imageSrc: string;
+  command?: string;
+  response?: string;
 }
 
 const SetupProject = (props: SetupProjectProp) => {

--- a/website/docs/dapp/_SetupProjectContent.mdx
+++ b/website/docs/dapp/_SetupProjectContent.mdx
@@ -2,6 +2,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import ImgContainer from "@components/ImgContainer";
 import useBaseUrl from "@docusaurus/useBaseUrl";
+import CodeBlock from "@theme/CodeBlock";
 import StartDevnet from "./_StartDevnet.mdx";
 
 <StartDevnet />
@@ -15,27 +16,28 @@ Navigate to your project, install the node dependencies, and start running the e
   <TabItem value="offckb-npm-start" label="Command">
 ```
 
-```bash
-npm install && NETWORK=devnet npm start
-```
+<CodeBlock language="bash">
+  {props.command ?? "npm install && NETWORK=devnet npm start"}
+</CodeBlock>
 
 ```mdx-code-block
   </TabItem>
   <TabItem value="offckb-npm-start-result" label="Response">
 ```
 
-```bash
-$ parcel index.html
+<CodeBlock language="bash">
+  {props.response ??
+    `$ parcel index.html
 Server running at http://localhost:1234
-✨ Built in 66ms
-```
+✨ Built in 66ms`}
+</CodeBlock>
 
 ```mdx-code-block
   </TabItem>
 </Tabs>
 ```
 
-Now, the app is running in http://localhost:1234
+Now, the app is running at [http://localhost:1234](http://localhost:1234).
 
 <ImgContainer src={useBaseUrl(props.imageSrc)} />
 

--- a/website/docs/dapp/simple-lock.mdx
+++ b/website/docs/dapp/simple-lock.mdx
@@ -40,7 +40,7 @@ import Link from "@docusaurus/Link";
     </div>,
     <div key="node">
       <Link href="https://nodejs.org/" target="_blank">
-        Node.js 18.18 or later
+        Node.js 20 or later
       </Link>
     </div>,
     <div key="pnpm">

--- a/website/docs/dapp/write-message.mdx
+++ b/website/docs/dapp/write-message.mdx
@@ -66,7 +66,7 @@ import Link from "@docusaurus/Link";
 
 ## Tutorial Overview
 
-In this tutorial, you will learn how to tuck a nifty message - "**Hello CKB!**" - into a <Tooltip>Cell</Tooltip> on the CKB blockchain. Imagine it as sending a message in a bottle, but the ocean is digital, and the bottle is a super secure, tamper-proof CKB Cell!
+In this tutorial, you will learn how to tuck a nifty message - "**hello common knowledge base!**" - into a <Tooltip>Cell</Tooltip> on the CKB blockchain. Imagine it as sending a message in a bottle, but the ocean is digital, and the bottle is a super secure, tamper-proof CKB Cell!
 
 As you learned from the first tutorial, [Transfer CKB](/docs/dapp/transfer-ckb), a Cell can store any type of data in the data field of the Cell structure. Here, we will encode a text message as a hex string and store it in the data field. Once your words are encoded and inscribed into the blockchain, we'll get the hex string back from the same Cell and decode it to the original text message. The encoding and decoding method is up to you; we use `TextDecoder` for simplicity throughout the tutorial.
 
@@ -94,7 +94,7 @@ Server running at http://localhost:1234
 ✨ Built in ...`}
 />
 
-`npm start` refreshes the Devnet system-script references from OffCKB before launching the dApp. It uses the local Devnet at `http://127.0.0.1:28114`. The dApp itself opens at [http://localhost:1234](http://localhost:1234); the RPC endpoint does not serve a webpage.
+`npm start` exports the system-script references from the initialized local OffCKB Devnet before launching the dApp. The dApp connects to its RPC proxy at [http://127.0.0.1:28114](http://127.0.0.1:28114). The dApp itself opens at [http://localhost:1234](http://localhost:1234); the RPC endpoint does not serve a webpage.
 
 ## Behind the Scene
 
@@ -134,7 +134,7 @@ Now, check out the core function `buildMessageTx`. It requires two parameters:
 - **Private Key**: Your private key, used for transaction authorization.
 - **Message**: The message you want to write into the Cell.
 
-The function then constructs a transaction to create a new Cell that incorporates the specified message in the data field
+The function then constructs a transaction to create a new Cell that incorporates the specified message in the data field.
 
 ```ts
 export async function buildMessageTx(
@@ -184,7 +184,7 @@ To retrieve a specific Live Cell, we use the RPC method `getLiveCell` with `OutP
 
 Given a specific transaction hash, we can locate the output Cells of the transaction. By knowing the position index of the Cell, we can find out the specific one.
 
-For the way we built the transaction, we know that the Live Cell that carries the message is always the first one of the output Cells. So we set `index = "0x0"`
+For the way we built the transaction, we know that the Live Cell that carries the message is always the first one of the output Cells. So we set `index = "0x0"`.
 
 ```ts title="lib.ts" {8}
 type ReadMessageOptions = {
@@ -224,7 +224,7 @@ After following this tutorial, you have mastered how storing data on Cells works
 
 - We can store arbitrary data in the `data` field of Cell.
 - We need a way to encode and decode our data for understanding and using our raw on-chain data later.
-- To read the storing data, we need to locate the Live Cell that we put our data in. This can be done by querying Cells meets our requirement or by getting the Cell directly with a known `OutPoint` through RPC.
+- To read the storing data, we need to locate the Live Cell that we put our data in. This can be done by querying Cells that meet our requirement or by getting the Cell directly with a known `OutPoint` through RPC.
 
 ## Next Step: Try Testnet
 

--- a/website/docs/dapp/write-message.mdx
+++ b/website/docs/dapp/write-message.mdx
@@ -16,20 +16,53 @@ related:
   - /docs/tech-explanation/outputs-data
   - /docs/sdk-and-devtool/ccc
 difficulty: beginner
-last_reviewed: 2026-06-24
+last_reviewed: 2026-08-28
 ---
 
-import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem";
 import TutorialHeader from "@components/TutorialHeader";
 import Tooltip from "@components/Tooltip";
 import SetupProject from "./SetupProject.tsx";
-import SwitchToTestnet from "./_SwitchToTestnet.tsx";
 import ExampleLink from "@components/ExampleLink";
+import Link from "@docusaurus/Link";
 
 # Store Data on Cell
 
-<TutorialHeader time={"2 - 5 min"} tools={"dapp"} />
+<TutorialHeader
+  time={"2 - 5 min"}
+  requiredTools={[
+    <div key="git">
+      <Link href="https://git-scm.com/" target="_blank">
+        Git
+      </Link>
+    </div>,
+    <div key="node">
+      <Link href="https://nodejs.org/" target="_blank">
+        Node.js 20 or later
+      </Link>
+    </div>,
+    <div key="npm">
+      <Link
+        href="https://docs.npmjs.com/downloading-and-installing-node-js-and-npm"
+        target="_blank"
+      >
+        npm
+      </Link>
+    </div>,
+    <div key="offckb">
+      <Link to="/docs/node/run-devnet-node">OffCKB</Link>
+    </div>,
+  ]}
+>
+  <details>
+    <summary>Setup checks</summary>
+    <p>Verify the required commands before starting:</p>
+    <pre>
+      <code>
+        {"git --version\nnode --version\nnpm --version\noffckb --version"}
+      </code>
+    </pre>
+  </details>
+</TutorialHeader>
 
 ## Tutorial Overview
 
@@ -52,7 +85,16 @@ You can also read the full code online or download it <ExampleLink path="dApp/st
 
 ### Step 2: Start the Devnet
 
-<SetupProject imageSrc="img/dapps/store-data.png" />
+<SetupProject
+  imageSrc="img/dapps/store-data.png"
+  command={"npm install\nnpm start"}
+  response={`File .../system-scripts.json generated successfully.
+Synchronized Devnet system scripts with OffCKB.
+Server running at http://localhost:1234
+✨ Built in ...`}
+/>
+
+`npm start` refreshes the Devnet system-script references from OffCKB before launching the dApp. It uses the local Devnet at `http://127.0.0.1:28114`. The dApp itself opens at [http://localhost:1234](http://localhost:1234); the RPC endpoint does not serve a webpage.
 
 ## Behind the Scene
 
@@ -123,13 +165,13 @@ await tx.completeInputsByCapacity(signer);
 await tx.completeFeeBy(signer, 1000);
 ```
 
-Lastly, we use signer to sign and broadcast the transaction to the blockchain network through rpc:
+Lastly, we use the signer to sign and broadcast the transaction through RPC:
 
 ```ts
 const txHash = await signer.sendTransaction(tx);
 ```
 
-Therefore, the message is successfully stored on a Cell and lives in the blockchain.
+Broadcasting returns a transaction hash immediately. The dApp then waits until the transaction is committed and its output Cell becomes live before enabling **Read**.
 
 ### Read Cell Messages
 
@@ -144,16 +186,33 @@ Given a specific transaction hash, we can locate the output Cells of the transac
 
 For the way we built the transaction, we know that the Live Cell that carries the message is always the first one of the output Cells. So we set `index = "0x0"`
 
-```ts
-export async function readOnChainMessage(txHash: string, index = "0x0") {
-  const cell = await cccClient.getCellLive({ txHash, index }, true);
-  if (cell == null) {
-    return alert("Cell not found, please retry later");
+```ts title="lib.ts" {8}
+type ReadMessageOptions = {
+  intervalMs?: number;
+  maxAttempts?: number;
+};
+
+export async function readOnChainMessage(
+  txHash: string,
+  index = "0x0",
+  options: ReadMessageOptions = {}
+) {
+  const { intervalMs = 1000, maxAttempts = 30 } = options;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const cell = await cccClient.getCellLive({ txHash, index }, true);
+    if (cell != null) {
+      return hexToUtf8(cell.outputData);
+    }
+
+    if (attempt < maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
   }
-  const data = cell.outputData;
-  const msg = hexToUtf8(data);
-  alert("read msg: " + msg);
-  return msg;
+
+  throw new Error(
+    "The message Cell is not live yet. Wait for the transaction to be committed, then try again."
+  );
 }
 ```
 
@@ -167,9 +226,20 @@ After following this tutorial, you have mastered how storing data on Cells works
 - We need a way to encode and decode our data for understanding and using our raw on-chain data later.
 - To read the storing data, we need to locate the Live Cell that we put our data in. This can be done by querying Cells meets our requirement or by getting the Cell directly with a known `OutPoint` through RPC.
 
-## Next Step
+## Next Step: Try Testnet
 
-<SwitchToTestnet readmeLink="dApp/store-data-on-cell" />
+After the local flow works, you can run the same dApp on Testnet:
+
+1. Create a separate Testnet account and fund it from the [CKB Testnet Faucet](https://faucet.nervos.org/).
+2. Restart the dApp with:
+
+   ```bash
+   npm run start:testnet
+   ```
+
+3. Enter the funded Testnet private key in the dApp.
+
+Never use a Mainnet private key or Mainnet assets in this tutorial.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary
Improve the Store Data on Cell tutorial and runnable example.

## Changes
- Make Devnet the default and add an explicit Testnet startup path
- Block Mainnet usage and display the active network and RPC endpoint
- Refresh OffCKB system-script references before local startup and production builds
- Wait for the output Cell to become live before enabling Read and add confirmation retry states
- Add actionable connection errors and display the decoded on-chain message in the UI
- Expand prerequisites, setup commands, expected output, Testnet steps, and troubleshooting guidance
- Add build cleanup and browser-bundle verification safeguards
- Correct the example page title and align Simple Lock with the Node.js 20 prerequisite