### PR TITLE
fix(docs): redirect Broken Journeys 404 legacy URLs

### DIFF
--- a/website/docs/dapp/transfer-ckb.mdx
+++ b/website/docs/dapp/transfer-ckb.mdx
@@ -13,7 +13,7 @@ audience:
 related:
   - /docs/getting-started/quick-start
   - /docs/sdk-and-devtool/ccc
-  - /docs/dapp/write-message
+  - /docs/dapp/store-data-on-cell
   - /docs/ckb-fundamentals/cell-model
 difficulty: beginner
 last_reviewed: 2026-06-24

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -498,10 +498,7 @@ const config = {
             to: "/docs/ckb-fundamentals/cell-model",
           },
           {
-            from: [
-              "/key-concepts/consensus.html",
-              "/key-concepts/consensus",
-            ],
+            from: ["/key-concepts/consensus.html", "/key-concepts/consensus"],
             to: "/docs/ckb-fundamentals/consensus",
           },
           {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -487,6 +487,55 @@ const config = {
             from: "/docs/essays/upgradability",
             to: "https://docs-old.nervos.org/docs/essays/upgradability",
           },
+          {
+            // 2019-era key-concepts / basic-concepts HTML routes (Broken Journeys)
+            from: [
+              "/key-concepts/cell-model.html",
+              "/key-concepts/cell-model",
+              "/basic-concepts/cell-model.html",
+              "/basic-concepts/cell-model",
+            ],
+            to: "/docs/ckb-fundamentals/cell-model",
+          },
+          {
+            from: [
+              "/key-concepts/consensus.html",
+              "/key-concepts/consensus",
+            ],
+            to: "/docs/ckb-fundamentals/consensus",
+          },
+          {
+            from: [
+              "/glossary/glossary-general.html",
+              "/glossary/glossary-general",
+            ],
+            to: "/docs/tech-explanation/glossary",
+          },
+          {
+            // File is write-message.mdx but doc id/slug is store-data-on-cell
+            from: "/docs/dapp/write-message",
+            to: "/docs/dapp/store-data-on-cell",
+          },
+          {
+            // Relocated in #423 to how-to-query-tx-state
+            from: "/docs/how-tos/how-to-manage-txs",
+            to: "/docs/how-tos/how-to-query-tx-state",
+          },
+          {
+            // Blog removed; postsPerPage:1 ascending — page N was script-course N
+            // (same mapping pattern as existing /blog/page/3 redirect)
+            from: "/blog/page/7",
+            to: "/docs/script/js/js-vm",
+          },
+          {
+            from: "/blog/page/8",
+            to: "/docs/script/program-language-for-script",
+          },
+          {
+            // Docs tag index not generated for this tag; send to the topic page
+            from: "/docs/tags/cell-model",
+            to: "/docs/ckb-fundamentals/cell-model",
+          },
         ],
         createRedirects(existingPath) {
           if (


### PR DESCRIPTION
## Summary
Adds permanent client redirects for high-value 404 paths from Umami **Broken Journeys** reports, and fixes one internal docs link that still pointed at a broken path.

## Redirects (`website/docusaurus.config.js`)
| From | To | Why |
|------|----|-----|
| `/key-concepts/cell-model.html` (+ extensionless, `/basic-concepts` variants) | `/docs/ckb-fundamentals/cell-model` | Legacy pre-Docusaurus / old taxonomy |
| `/key-concepts/consensus.html` (+ extensionless) | `/docs/ckb-fundamentals/consensus` | Legacy key-concepts route |
| `/glossary/glossary-general.html` (+ extensionless) | `/docs/tech-explanation/glossary` | Legacy glossary URL |
| `/docs/dapp/write-message` | `/docs/dapp/store-data-on-cell` | File remains `write-message.mdx` but doc `id`/slug is `store-data-on-cell` |
| `/docs/how-tos/how-to-manage-txs` | `/docs/how-tos/how-to-query-tx-state` | Relocated in #423 |
| `/blog/page/7` | `/docs/script/js/js-vm` | Blog removed; same `postsPerPage: 1` ascending mapping pattern as existing `/blog/page/3` |
| `/blog/page/8` | `/docs/script/program-language-for-script` | Same blog→script-course series mapping |
| `/docs/tags/cell-model` | `/docs/ckb-fundamentals/cell-model` | Tag index not generated; send to topic page |

## Internal link fix
- `website/docs/dapp/transfer-ckb.mdx` `related`: `/docs/dapp/write-message` → `/docs/dapp/store-data-on-cell`

## Test plan
- [ ] Confirm successor pages 200 on preview/prod
- [ ] Hit each `from` path and confirm client redirect to `to`
- [ ] Confirm `transfer-ckb` related link resolves